### PR TITLE
GPU-native AtomSpace Phase 0-1: hash table + pool layouts

### DIFF
--- a/opencog/opencl/atomspace/.gitignore
+++ b/opencog/opencl/atomspace/.gitignore
@@ -1,0 +1,8 @@
+# Compiled test binaries
+test-hashtable
+test-atomspace
+test-counting
+test-mi
+test-sections
+test-cosine
+test-substitute

--- a/opencog/opencl/atomspace/gpu-atomspace.cl
+++ b/opencog/opencl/atomspace/gpu-atomspace.cl
@@ -1,0 +1,407 @@
+/*
+ * gpu-atomspace.cl -- GPU-resident AtomSpace pools
+ *
+ * Three flat SoA (struct-of-arrays) pools for uniform-size atoms:
+ *   - WordPool:    words/concepts (nodes)
+ *   - PairPool:    word pairs (binary links)
+ *   - SectionPool: word+disjunct (sections for connector vectors)
+ *
+ * Each pool has:
+ *   - A bump allocator (atomic counter for next free slot)
+ *   - A hash table mapping content hash → pool index
+ *   - SoA arrays for each field (coalesced GPU access)
+ *
+ * All counting uses atomic operations (CAS-loop for doubles).
+ *
+ * This file is concatenated after gpu-hashtable.cl at load time,
+ * so ht_hash(), atom_cmpxchg, HT_EMPTY_KEY etc. are available.
+ */
+
+/* ─── Double-precision atomic add via CAS loop ─── */
+
+/*
+ * OpenCL has no native atomicAdd for doubles. We implement it
+ * via compare-and-swap on the 64-bit integer representation.
+ * Uses atom_cmpxchg from cl_khr_int64_base_atomics.
+ */
+void atomic_add_double(__global volatile double* addr, double val)
+{
+    union { ulong i; double f; } next, expected, current;
+    current.f = *addr;
+    do {
+        expected = current;
+        next.f = expected.f + val;
+        current.i = atom_cmpxchg(
+            (__global volatile ulong*)addr,
+            expected.i, next.i);
+    } while (current.i != expected.i);
+}
+
+/* ─── Pool capacity constants (set by host at compile time) ─── */
+
+/* These are defined as macros by the host via -D flags:
+ *   WORD_CAPACITY     max words     (e.g., 131072 = 128K)
+ *   PAIR_CAPACITY     max pairs     (e.g., 4194304 = 4M)
+ *   SECTION_CAPACITY  max sections  (e.g., 1048576 = 1M)
+ *   WORD_HT_CAPACITY  word hash table size (power of 2)
+ *   PAIR_HT_CAPACITY  pair hash table size (power of 2)
+ *   SECTION_HT_CAPACITY section hash table size (power of 2)
+ */
+
+/* ═══════════════════════════════════════════════════════════════
+ *  WORD POOL — Nodes
+ *
+ *  SoA layout:
+ *    word_name_hash[N]   ulong   — content hash (from string)
+ *    word_count[N]       double  — marginal count
+ *    word_mi_marginal[N] double  — sum of MI for marginal
+ *    word_class_id[N]    uint    — class assignment (0 = none)
+ *
+ *  Hash table: name_hash → word_index
+ * ═══════════════════════════════════════════════════════════════ */
+
+/*
+ * Find or create words in the pool.
+ *
+ * For each input name_hash, looks up in the word hash table.
+ * If found, returns the existing index. If not found, atomically
+ * allocates a new slot and initializes it.
+ *
+ * Args:
+ *   wht_keys, wht_values  - word hash table (keys + values)
+ *   word_name_hash         - word pool: name hashes
+ *   word_count             - word pool: counts (init to 0.0)
+ *   word_class_id          - word pool: class IDs (init to 0)
+ *   word_next_free         - atomic bump allocator (single uint)
+ *   in_name_hashes         - input: name hashes to find/create
+ *   out_indices            - output: pool index for each input
+ *   num_items              - number of inputs
+ */
+__kernel void word_find_or_create(
+    __global volatile ulong* wht_keys,
+    __global volatile uint*  wht_values,
+    __global ulong*          word_name_hash,
+    __global double*         word_count,
+    __global uint*           word_class_id,
+    __global volatile uint*  word_next_free,
+    __global const ulong*    in_name_hashes,
+    __global uint*           out_indices,
+    const uint               num_items)
+{
+    uint tid = get_global_id(0);
+    if (tid >= num_items) return;
+
+    ulong name_hash = in_name_hashes[tid];
+    if (name_hash == HT_EMPTY_KEY) {
+        out_indices[tid] = HT_EMPTY_VALUE;
+        return;
+    }
+
+    ulong ht_cap = WORD_HT_CAPACITY;
+    ulong mask = ht_cap - 1;
+    ulong slot = ht_hash(name_hash) & mask;
+
+    for (uint probe = 0; probe < HT_MAX_PROBES; probe++)
+    {
+        ulong prev = atom_cmpxchg(&wht_keys[slot], HT_EMPTY_KEY, name_hash);
+
+        if (prev == HT_EMPTY_KEY)
+        {
+            /* We won the slot — allocate from pool and publish value */
+            uint idx = atomic_add(word_next_free, 1U);
+            if (idx < WORD_CAPACITY) {
+                word_name_hash[idx] = name_hash;
+                word_count[idx] = 0.0;
+                word_class_id[idx] = 0;
+                /* Write value LAST so spin-waiters see valid index */
+                mem_fence(CLK_GLOBAL_MEM_FENCE);
+                wht_values[slot] = idx;
+                out_indices[tid] = idx;
+            } else {
+                out_indices[tid] = HT_EMPTY_VALUE;
+            }
+            return;
+        }
+        if (prev == name_hash)
+        {
+            /* Already exists — spin until creator publishes value */
+            uint val = wht_values[slot];
+            while (val == HT_EMPTY_VALUE) {
+                val = wht_values[slot];
+            }
+            out_indices[tid] = val;
+            return;
+        }
+
+        slot = (slot + 1) & mask;
+    }
+    out_indices[tid] = HT_EMPTY_VALUE;
+}
+
+/* ═══════════════════════════════════════════════════════════════
+ *  PAIR POOL — Binary Links (word pairs)
+ *
+ *  SoA layout:
+ *    pair_word_a[N]  uint    — index into WordPool
+ *    pair_word_b[N]  uint    — index into WordPool
+ *    pair_count[N]   double  — joint count
+ *    pair_mi[N]      double  — mutual information
+ *    pair_flags[N]   uint    — dirty bit, etc.
+ *
+ *  Hash table key: (word_a << 32) | word_b  (packed 64-bit)
+ * ═══════════════════════════════════════════════════════════════ */
+
+/* Pack two 32-bit word indices into a single 64-bit hash key */
+inline ulong pair_key(uint word_a, uint word_b)
+{
+    /* Always store with smaller index first for canonical ordering */
+    uint lo = min(word_a, word_b);
+    uint hi = max(word_a, word_b);
+    return ((ulong)lo << 32) | (ulong)hi;
+}
+
+/*
+ * Find or create word pairs in the pool.
+ *
+ * Args:
+ *   pht_keys, pht_values  - pair hash table
+ *   pair_word_a, pair_word_b - pair pool: word indices
+ *   pair_count             - pair pool: counts (init to 0.0)
+ *   pair_mi                - pair pool: MI values (init to 0.0)
+ *   pair_flags             - pair pool: flags (init to 0)
+ *   pair_next_free         - atomic bump allocator
+ *   in_word_a, in_word_b   - input: word index pairs
+ *   out_indices            - output: pair pool index for each input
+ *   num_items              - number of inputs
+ */
+__kernel void pair_find_or_create(
+    __global volatile ulong* pht_keys,
+    __global volatile uint*  pht_values,
+    __global uint*           pair_word_a,
+    __global uint*           pair_word_b,
+    __global double*         pair_count,
+    __global double*         pair_mi,
+    __global uint*           pair_flags,
+    __global volatile uint*  pair_next_free,
+    __global const uint*     in_word_a,
+    __global const uint*     in_word_b,
+    __global uint*           out_indices,
+    const uint               num_items)
+{
+    uint tid = get_global_id(0);
+    if (tid >= num_items) return;
+
+    uint wa = in_word_a[tid];
+    uint wb = in_word_b[tid];
+    ulong key = pair_key(wa, wb);
+
+    ulong ht_cap = PAIR_HT_CAPACITY;
+    ulong mask = ht_cap - 1;
+    ulong slot = ht_hash(key) & mask;
+
+    for (uint probe = 0; probe < HT_MAX_PROBES; probe++)
+    {
+        ulong prev = atom_cmpxchg(&pht_keys[slot], HT_EMPTY_KEY, key);
+
+        if (prev == HT_EMPTY_KEY)
+        {
+            uint idx = atomic_add(pair_next_free, 1U);
+            if (idx < PAIR_CAPACITY) {
+                pair_word_a[idx] = min(wa, wb);
+                pair_word_b[idx] = max(wa, wb);
+                pair_count[idx] = 0.0;
+                pair_mi[idx] = 0.0;
+                pair_flags[idx] = 0;
+                mem_fence(CLK_GLOBAL_MEM_FENCE);
+                pht_values[slot] = idx;
+                out_indices[tid] = idx;
+            } else {
+                out_indices[tid] = HT_EMPTY_VALUE;
+            }
+            return;
+        }
+        if (prev == key)
+        {
+            uint val = pht_values[slot];
+            while (val == HT_EMPTY_VALUE) {
+                val = pht_values[slot];
+            }
+            out_indices[tid] = val;
+            return;
+        }
+
+        slot = (slot + 1) & mask;
+    }
+    out_indices[tid] = HT_EMPTY_VALUE;
+}
+
+/* ═══════════════════════════════════════════════════════════════
+ *  SECTION POOL — Word + Disjunct
+ *
+ *  SoA layout:
+ *    sec_word[N]          uint    — index into WordPool
+ *    sec_disjunct_hash[N] ulong   — hash of full disjunct string
+ *    sec_count[N]         double  — section count
+ *
+ *  Hash table key: hash(word_idx, disjunct_hash)
+ * ═══════════════════════════════════════════════════════════════ */
+
+/* Combine word index and disjunct hash into a single 64-bit key */
+inline ulong section_key(uint word_idx, ulong disjunct_hash)
+{
+    /* Mix the word index into the disjunct hash */
+    ulong key = disjunct_hash ^ ((ulong)word_idx * 0x9E3779B97F4A7C15UL);
+    /* Ensure it's never the sentinel */
+    if (key == HT_EMPTY_KEY) key = 0;
+    return key;
+}
+
+/*
+ * Find or create sections in the pool.
+ *
+ * Args:
+ *   sht_keys, sht_values   - section hash table
+ *   sec_word               - section pool: word indices
+ *   sec_disjunct_hash      - section pool: disjunct hashes
+ *   sec_count              - section pool: counts (init to 0.0)
+ *   sec_next_free          - atomic bump allocator
+ *   in_word_indices        - input: word indices
+ *   in_disjunct_hashes     - input: disjunct hashes
+ *   out_indices            - output: section pool index
+ *   num_items              - number of inputs
+ */
+__kernel void section_find_or_create(
+    __global volatile ulong* sht_keys,
+    __global volatile uint*  sht_values,
+    __global uint*           sec_word,
+    __global ulong*          sec_disjunct_hash,
+    __global double*         sec_count,
+    __global volatile uint*  sec_next_free,
+    __global const uint*     in_word_indices,
+    __global const ulong*    in_disjunct_hashes,
+    __global uint*           out_indices,
+    const uint               num_items)
+{
+    uint tid = get_global_id(0);
+    if (tid >= num_items) return;
+
+    uint widx = in_word_indices[tid];
+    ulong dhash = in_disjunct_hashes[tid];
+    ulong key = section_key(widx, dhash);
+
+    ulong ht_cap = SECTION_HT_CAPACITY;
+    ulong mask = ht_cap - 1;
+    ulong slot = ht_hash(key) & mask;
+
+    for (uint probe = 0; probe < HT_MAX_PROBES; probe++)
+    {
+        ulong prev = atom_cmpxchg(&sht_keys[slot], HT_EMPTY_KEY, key);
+
+        if (prev == HT_EMPTY_KEY)
+        {
+            uint idx = atomic_add(sec_next_free, 1U);
+            if (idx < SECTION_CAPACITY) {
+                sec_word[idx] = widx;
+                sec_disjunct_hash[idx] = dhash;
+                sec_count[idx] = 0.0;
+                mem_fence(CLK_GLOBAL_MEM_FENCE);
+                sht_values[slot] = idx;
+                out_indices[tid] = idx;
+            } else {
+                out_indices[tid] = HT_EMPTY_VALUE;
+            }
+            return;
+        }
+        if (prev == key)
+        {
+            uint val = sht_values[slot];
+            while (val == HT_EMPTY_VALUE) {
+                val = sht_values[slot];
+            }
+            out_indices[tid] = val;
+            return;
+        }
+
+        slot = (slot + 1) & mask;
+    }
+    out_indices[tid] = HT_EMPTY_VALUE;
+}
+
+/* ═══════════════════════════════════════════════════════════════
+ *  COUNTING OPERATIONS
+ *
+ *  Atomic double-precision increments on pool arrays.
+ * ═══════════════════════════════════════════════════════════════ */
+
+/*
+ * Increment pair counts by 1.0 for given pair indices.
+ * Also increments word marginal counts for both words.
+ */
+__kernel void count_pairs(
+    __global volatile double* pair_count,
+    __global const uint*      pair_word_a,
+    __global const uint*      pair_word_b,
+    __global volatile double* word_count,
+    __global volatile uint*   pair_flags,
+    __global const uint*      pair_indices,
+    const uint                num_items)
+{
+    uint tid = get_global_id(0);
+    if (tid >= num_items) return;
+
+    uint pidx = pair_indices[tid];
+    if (pidx == HT_EMPTY_VALUE) return;
+
+    /* Increment pair count */
+    atomic_add_double(&pair_count[pidx], 1.0);
+
+    /* Increment word marginals */
+    uint wa = pair_word_a[pidx];
+    uint wb = pair_word_b[pidx];
+    atomic_add_double(&word_count[wa], 1.0);
+    atomic_add_double(&word_count[wb], 1.0);
+
+    /* Mark pair as dirty (needs MI recomputation) */
+    pair_flags[pidx] = 1;
+}
+
+/*
+ * Increment section counts by 1.0 for given section indices.
+ */
+__kernel void count_sections(
+    __global volatile double* sec_count,
+    __global const uint*      sec_indices,
+    const uint                num_items)
+{
+    uint tid = get_global_id(0);
+    if (tid >= num_items) return;
+
+    uint sidx = sec_indices[tid];
+    if (sidx == HT_EMPTY_VALUE) return;
+
+    atomic_add_double(&sec_count[sidx], 1.0);
+}
+
+/* ═══════════════════════════════════════════════════════════════
+ *  POOL STATISTICS
+ *
+ *  Read back pool sizes (bump allocator values).
+ * ═══════════════════════════════════════════════════════════════ */
+
+/*
+ * Read pool sizes into output array.
+ * out_stats[0] = word count
+ * out_stats[1] = pair count
+ * out_stats[2] = section count
+ */
+__kernel void pool_stats(
+    __global const uint* word_next_free,
+    __global const uint* pair_next_free,
+    __global const uint* sec_next_free,
+    __global uint*       out_stats)
+{
+    if (get_global_id(0) != 0) return;
+    out_stats[0] = *word_next_free;
+    out_stats[1] = *pair_next_free;
+    out_stats[2] = *sec_next_free;
+}

--- a/opencog/opencl/atomspace/gpu-hashtable.cl
+++ b/opencog/opencl/atomspace/gpu-hashtable.cl
@@ -1,0 +1,303 @@
+/*
+ * gpu-hashtable.cl -- Lock-free GPU hash table using linear probing
+ *
+ * Open-addressing hash table for mapping 64-bit keys to 32-bit values.
+ * Designed for GPU-resident AtomSpace: maps atom content hashes to
+ * pool indices (slots in flat SoA arrays).
+ *
+ * Based on: nosferalatu/SimpleGPUHashTable (CUDA) and
+ *           LANL/CompactHash (OpenCL)
+ *
+ * Key properties:
+ *   - Lock-free concurrent insert/lookup via atomic CAS
+ *   - Linear probing with power-of-two table size
+ *   - 64-bit keys (atom content hashes)
+ *   - 32-bit values (pool indices)
+ *   - Sentinel key 0xFFFFFFFFFFFFFFFF marks empty slots
+ *   - Sentinel value 0xFFFFFFFF marks deleted entries
+ *   - 50% load factor recommended (trade memory for speed)
+ *
+ * Requires: cl_khr_int64_base_atomics
+ */
+
+#pragma OPENCL EXTENSION cl_khr_int64_base_atomics : enable
+
+/* ─── Constants ─── */
+
+/* Empty slot sentinel — no valid atom hash should equal this */
+#define HT_EMPTY_KEY    0xFFFFFFFFFFFFFFFFUL
+/* Deleted value sentinel — key stays, value marks as deleted */
+#define HT_EMPTY_VALUE  0xFFFFFFFFU
+/* Max probes before giving up (prevents infinite loops on full table) */
+#define HT_MAX_PROBES   4096
+
+/* ─── Hash function ─── */
+
+/*
+ * 64-bit finalizer from splitmix64 / Murmur3.
+ * Produces well-distributed hashes from sequential or clustered keys.
+ */
+inline ulong ht_hash(ulong key)
+{
+    key ^= key >> 30;
+    key *= 0xBF58476D1CE4E5B9UL;
+    key ^= key >> 27;
+    key *= 0x94D049BB133111EBUL;
+    key ^= key >> 31;
+    return key;
+}
+
+/* ─── Insert ─── */
+
+/*
+ * Insert key-value pairs into the hash table.
+ *
+ * Each work-item handles one (key, value) pair.
+ * Uses atomic CAS on the key slot: if the slot is empty or already
+ * contains our key, we write the value. Otherwise linear-probe forward.
+ *
+ * Args:
+ *   table_keys   - key array   [capacity]  (ulong)
+ *   table_values - value array  [capacity]  (uint)
+ *   capacity     - table size (must be power of 2)
+ *   in_keys      - keys to insert   [num_items]
+ *   in_values    - values to insert  [num_items]
+ *   num_items    - number of items to insert
+ */
+__kernel void ht_insert(
+    __global volatile ulong* table_keys,
+    __global uint*           table_values,
+    const ulong              capacity,
+    __global const ulong*    in_keys,
+    __global const uint*     in_values,
+    const uint               num_items)
+{
+    uint tid = get_global_id(0);
+    if (tid >= num_items) return;
+
+    ulong key   = in_keys[tid];
+    uint  value = in_values[tid];
+
+    /* Don't insert the sentinel key */
+    if (key == HT_EMPTY_KEY) return;
+
+    ulong mask = capacity - 1;  /* power-of-2 masking */
+    ulong slot = ht_hash(key) & mask;
+
+    for (uint probe = 0; probe < HT_MAX_PROBES; probe++)
+    {
+        /* Try to claim this slot with our key */
+        ulong prev = atom_cmpxchg(
+            &table_keys[slot], HT_EMPTY_KEY, key);
+
+        if (prev == HT_EMPTY_KEY || prev == key)
+        {
+            /* Slot was empty or already ours — write value */
+            table_values[slot] = value;
+            return;
+        }
+
+        /* Slot taken by another key — linear probe */
+        slot = (slot + 1) & mask;
+    }
+    /* Table full or too many collisions — item not inserted */
+}
+
+/* ─── Lookup ─── */
+
+/*
+ * Look up keys in the hash table, returning their values.
+ *
+ * Each work-item looks up one key. If found, writes the value
+ * to out_values[tid]. If not found, writes HT_EMPTY_VALUE.
+ *
+ * Args:
+ *   table_keys   - key array   [capacity]  (ulong)
+ *   table_values - value array  [capacity]  (uint)
+ *   capacity     - table size (must be power of 2)
+ *   query_keys   - keys to look up    [num_queries]
+ *   out_values   - results written here [num_queries]
+ *   num_queries  - number of lookups
+ */
+__kernel void ht_lookup(
+    __global const ulong* table_keys,
+    __global const uint*  table_values,
+    const ulong           capacity,
+    __global const ulong* query_keys,
+    __global uint*        out_values,
+    const uint            num_queries)
+{
+    uint tid = get_global_id(0);
+    if (tid >= num_queries) return;
+
+    ulong key = query_keys[tid];
+    ulong mask = capacity - 1;
+    ulong slot = ht_hash(key) & mask;
+
+    for (uint probe = 0; probe < HT_MAX_PROBES; probe++)
+    {
+        ulong slot_key = table_keys[slot];
+
+        if (slot_key == key)
+        {
+            /* Found — read value */
+            out_values[tid] = table_values[slot];
+            return;
+        }
+        if (slot_key == HT_EMPTY_KEY)
+        {
+            /* Empty slot — key not in table */
+            out_values[tid] = HT_EMPTY_VALUE;
+            return;
+        }
+
+        /* Different key — linear probe */
+        slot = (slot + 1) & mask;
+    }
+    /* Max probes exhausted — not found */
+    out_values[tid] = HT_EMPTY_VALUE;
+}
+
+/* ─── Delete ─── */
+
+/*
+ * Delete keys from the hash table.
+ *
+ * Tombstone deletion: key stays in table, value set to HT_EMPTY_VALUE.
+ * Preserves probe chains for other keys. Deleted slots are NOT reused
+ * for new inserts (keeps the algorithm simple).
+ *
+ * Args:
+ *   table_keys   - key array   [capacity]  (ulong)
+ *   table_values - value array  [capacity]  (uint)
+ *   capacity     - table size (must be power of 2)
+ *   del_keys     - keys to delete [num_deletes]
+ *   num_deletes  - number of deletions
+ */
+__kernel void ht_delete(
+    __global const ulong* table_keys,
+    __global uint*        table_values,
+    const ulong           capacity,
+    __global const ulong* del_keys,
+    const uint            num_deletes)
+{
+    uint tid = get_global_id(0);
+    if (tid >= num_deletes) return;
+
+    ulong key = del_keys[tid];
+    ulong mask = capacity - 1;
+    ulong slot = ht_hash(key) & mask;
+
+    for (uint probe = 0; probe < HT_MAX_PROBES; probe++)
+    {
+        ulong slot_key = table_keys[slot];
+
+        if (slot_key == key)
+        {
+            /* Found — tombstone the value */
+            table_values[slot] = HT_EMPTY_VALUE;
+            return;
+        }
+        if (slot_key == HT_EMPTY_KEY)
+        {
+            /* Not in table */
+            return;
+        }
+
+        slot = (slot + 1) & mask;
+    }
+}
+
+/* ─── Insert-or-increment ─── */
+
+/*
+ * Insert key with value, or atomically increment existing value.
+ * This is the core operation for AtomSpace counting: if the pair
+ * atom already exists, increment its count. Otherwise create it.
+ *
+ * IMPORTANT: table_values must be initialized to 0 (not 0xFF)
+ * before using this kernel. Both the "new slot" and "existing slot"
+ * paths use atomic_add(1), which avoids the race between CAS on
+ * the key and write to the value.
+ *
+ * Args:
+ *   table_keys   - key array   [capacity]  (ulong)
+ *   table_values - value array  [capacity]  (uint, init to 0)
+ *   capacity     - table size (must be power of 2)
+ *   in_keys      - keys to insert/increment  [num_items]
+ *   num_items    - number of items
+ */
+__kernel void ht_insert_or_increment(
+    __global volatile ulong* table_keys,
+    __global volatile uint*  table_values,
+    const ulong              capacity,
+    __global const ulong*    in_keys,
+    const uint               num_items)
+{
+    uint tid = get_global_id(0);
+    if (tid >= num_items) return;
+
+    ulong key = in_keys[tid];
+    if (key == HT_EMPTY_KEY) return;
+
+    ulong mask = capacity - 1;
+    ulong slot = ht_hash(key) & mask;
+
+    for (uint probe = 0; probe < HT_MAX_PROBES; probe++)
+    {
+        ulong prev = atom_cmpxchg(
+            &table_keys[slot], HT_EMPTY_KEY, key);
+
+        if (prev == HT_EMPTY_KEY || prev == key)
+        {
+            /* Slot is ours (new or existing) — atomic increment.
+             * Both paths do the same thing: no race between
+             * key placement and value update. */
+            atomic_add(&table_values[slot], 1U);
+            return;
+        }
+
+        slot = (slot + 1) & mask;
+    }
+}
+
+/* ─── Iterate (compact non-empty entries) ─── */
+
+/*
+ * Collect all non-empty, non-deleted entries into output arrays.
+ * Uses atomic counter to pack results contiguously.
+ *
+ * Args:
+ *   table_keys   - key array   [capacity]  (ulong)
+ *   table_values - value array  [capacity]  (uint)
+ *   capacity     - table size
+ *   out_keys     - output keys   [max_output]
+ *   out_values   - output values  [max_output]
+ *   out_count    - atomic counter (single uint, initialized to 0)
+ *   max_output   - max entries to output
+ */
+__kernel void ht_iterate(
+    __global const ulong* table_keys,
+    __global const uint*  table_values,
+    const ulong           capacity,
+    __global ulong*       out_keys,
+    __global uint*        out_values,
+    __global uint*        out_count,
+    const uint            max_output)
+{
+    uint tid = get_global_id(0);
+    if (tid >= capacity) return;
+
+    ulong key = table_keys[tid];
+    uint  val = table_values[tid];
+
+    if (key != HT_EMPTY_KEY && val != HT_EMPTY_VALUE)
+    {
+        uint idx = atomic_add(out_count, 1U);
+        if (idx < max_output)
+        {
+            out_keys[idx]   = key;
+            out_values[idx] = val;
+        }
+    }
+}

--- a/opencog/opencl/atomspace/test-atomspace.c
+++ b/opencog/opencl/atomspace/test-atomspace.c
@@ -1,0 +1,739 @@
+/*
+ * test-atomspace.c -- Test GPU-resident AtomSpace pools
+ *
+ * Compile: gcc -O2 -o test-atomspace test-atomspace.c -lOpenCL -lm
+ * Run:     ./test-atomspace
+ *
+ * Tests:
+ *   1. Create words (find-or-create with dedup)
+ *   2. Create pairs (find-or-create from word indices)
+ *   3. Create sections
+ *   4. Count pairs (atomic double increment + marginals)
+ *   5. Count sections
+ *   6. Verify counts read back correctly
+ *   7. Performance: create + count rates
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <math.h>
+#include <time.h>
+#include <CL/cl.h>
+
+/* ─── Pool capacities ─── */
+
+#define WORD_CAPACITY        (128 * 1024)    /* 128K words */
+#define PAIR_CAPACITY        (4 * 1024 * 1024) /* 4M pairs */
+#define SECTION_CAPACITY     (1024 * 1024)   /* 1M sections */
+
+/* Hash table sizes (2x pool capacity for 50% load) */
+#define WORD_HT_CAPACITY     (256 * 1024)
+#define PAIR_HT_CAPACITY     (8 * 1024 * 1024)
+#define SECTION_HT_CAPACITY  (2 * 1024 * 1024)
+
+#define HT_EMPTY_KEY    0xFFFFFFFFFFFFFFFFULL
+#define HT_EMPTY_VALUE  0xFFFFFFFFU
+
+/* ─── Error checking ─── */
+
+#define CL_CHECK(err, msg) do { \
+    if ((err) != CL_SUCCESS) { \
+        fprintf(stderr, "OpenCL error %d at %s:%d: %s\n", \
+                (err), __FILE__, __LINE__, (msg)); \
+        exit(1); \
+    } \
+} while(0)
+
+/* ─── Read file ─── */
+
+char* read_file(const char* path, size_t* len)
+{
+    FILE* f = fopen(path, "r");
+    if (!f) { fprintf(stderr, "Cannot open %s\n", path); exit(1); }
+    fseek(f, 0, SEEK_END);
+    *len = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    char* buf = malloc(*len + 1);
+    size_t n = fread(buf, 1, *len, f);
+    buf[n] = '\0';
+    *len = n;
+    fclose(f);
+    return buf;
+}
+
+/* ─── Simple hash for word names (CPU-side) ─── */
+
+uint64_t hash_word(const char* name)
+{
+    uint64_t h = 0x12345678DEADBEEFULL;
+    while (*name) {
+        h ^= (uint64_t)*name++;
+        h *= 0xBF58476D1CE4E5B9ULL;
+        h ^= h >> 31;
+    }
+    return h;
+}
+
+/* ─── Timing ─── */
+
+double now_ms(void)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return ts.tv_sec * 1000.0 + ts.tv_nsec / 1000000.0;
+}
+
+/* ─── Main ─── */
+
+int main(int argc, char** argv)
+{
+    cl_int err;
+
+    printf("=== GPU AtomSpace Pool Test ===\n\n");
+
+    /* ─── OpenCL setup ─── */
+
+    cl_platform_id platform;
+    err = clGetPlatformIDs(1, &platform, NULL);
+    CL_CHECK(err, "platform");
+
+    cl_device_id device;
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device, NULL);
+    CL_CHECK(err, "device");
+
+    char dev_name[256];
+    clGetDeviceInfo(device, CL_DEVICE_NAME, sizeof(dev_name), dev_name, NULL);
+    printf("GPU: %s\n", dev_name);
+
+    cl_context ctx = clCreateContext(NULL, 1, &device, NULL, NULL, &err);
+    CL_CHECK(err, "context");
+
+    cl_command_queue queue = clCreateCommandQueue(ctx, device, 0, &err);
+    CL_CHECK(err, "queue");
+
+    /* ─── Load and concatenate kernel sources ─── */
+
+    size_t ht_len, as_len;
+    char* ht_src = read_file("gpu-hashtable.cl", &ht_len);
+    char* as_src = read_file("gpu-atomspace.cl", &as_len);
+
+    /* Concatenate: hashtable first, then atomspace */
+    size_t total_len = ht_len + 1 + as_len;
+    char* combined = malloc(total_len + 1);
+    memcpy(combined, ht_src, ht_len);
+    combined[ht_len] = '\n';
+    memcpy(combined + ht_len + 1, as_src, as_len);
+    combined[total_len] = '\0';
+
+    cl_program program = clCreateProgramWithSource(ctx, 1,
+        (const char**)&combined, &total_len, &err);
+    CL_CHECK(err, "create program");
+
+    /* Build with capacity defines */
+    char build_opts[512];
+    snprintf(build_opts, sizeof(build_opts),
+        "-cl-std=CL1.2 "
+        "-DWORD_CAPACITY=%d "
+        "-DPAIR_CAPACITY=%d "
+        "-DSECTION_CAPACITY=%d "
+        "-DWORD_HT_CAPACITY=%d "
+        "-DPAIR_HT_CAPACITY=%d "
+        "-DSECTION_HT_CAPACITY=%d",
+        WORD_CAPACITY, PAIR_CAPACITY, SECTION_CAPACITY,
+        WORD_HT_CAPACITY, PAIR_HT_CAPACITY, SECTION_HT_CAPACITY);
+
+    err = clBuildProgram(program, 1, &device, build_opts, NULL, NULL);
+    if (err != CL_SUCCESS) {
+        char log[16384];
+        clGetProgramBuildInfo(program, device, CL_PROGRAM_BUILD_LOG,
+                              sizeof(log), log, NULL);
+        fprintf(stderr, "Build error:\n%s\n", log);
+        return 1;
+    }
+    printf("Kernels compiled successfully\n\n");
+
+    /* ─── Create kernels ─── */
+
+    cl_kernel k_word_foc = clCreateKernel(program, "word_find_or_create", &err);
+    CL_CHECK(err, "kernel word_find_or_create");
+    cl_kernel k_pair_foc = clCreateKernel(program, "pair_find_or_create", &err);
+    CL_CHECK(err, "kernel pair_find_or_create");
+    cl_kernel k_sec_foc = clCreateKernel(program, "section_find_or_create", &err);
+    CL_CHECK(err, "kernel section_find_or_create");
+    cl_kernel k_count_pairs = clCreateKernel(program, "count_pairs", &err);
+    CL_CHECK(err, "kernel count_pairs");
+    cl_kernel k_count_sec = clCreateKernel(program, "count_sections", &err);
+    CL_CHECK(err, "kernel count_sections");
+    cl_kernel k_stats = clCreateKernel(program, "pool_stats", &err);
+    CL_CHECK(err, "kernel pool_stats");
+
+    size_t local_size = 256;
+
+    /* ═══ ALLOCATE GPU BUFFERS ═══ */
+
+    printf("Allocating GPU buffers...\n");
+    uint8_t pat_ff = 0xFF;
+    uint8_t pat_00 = 0x00;
+
+    /* Word hash table */
+    cl_mem wht_keys = clCreateBuffer(ctx, CL_MEM_READ_WRITE,
+        sizeof(uint64_t) * WORD_HT_CAPACITY, NULL, &err);
+    CL_CHECK(err, "wht_keys");
+    cl_mem wht_values = clCreateBuffer(ctx, CL_MEM_READ_WRITE,
+        sizeof(uint32_t) * WORD_HT_CAPACITY, NULL, &err);
+    CL_CHECK(err, "wht_values");
+
+    /* Word pool SoA */
+    cl_mem word_name_hash = clCreateBuffer(ctx, CL_MEM_READ_WRITE,
+        sizeof(uint64_t) * WORD_CAPACITY, NULL, &err);
+    cl_mem word_count = clCreateBuffer(ctx, CL_MEM_READ_WRITE,
+        sizeof(double) * WORD_CAPACITY, NULL, &err);
+    cl_mem word_class_id = clCreateBuffer(ctx, CL_MEM_READ_WRITE,
+        sizeof(uint32_t) * WORD_CAPACITY, NULL, &err);
+
+    /* Word bump allocator */
+    uint32_t zero = 0;
+    cl_mem word_next_free = clCreateBuffer(ctx, CL_MEM_READ_WRITE | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint32_t), &zero, &err);
+
+    /* Pair hash table */
+    cl_mem pht_keys = clCreateBuffer(ctx, CL_MEM_READ_WRITE,
+        sizeof(uint64_t) * PAIR_HT_CAPACITY, NULL, &err);
+    cl_mem pht_values = clCreateBuffer(ctx, CL_MEM_READ_WRITE,
+        sizeof(uint32_t) * PAIR_HT_CAPACITY, NULL, &err);
+
+    /* Pair pool SoA */
+    cl_mem pair_word_a = clCreateBuffer(ctx, CL_MEM_READ_WRITE,
+        sizeof(uint32_t) * PAIR_CAPACITY, NULL, &err);
+    cl_mem pair_word_b = clCreateBuffer(ctx, CL_MEM_READ_WRITE,
+        sizeof(uint32_t) * PAIR_CAPACITY, NULL, &err);
+    cl_mem pair_count = clCreateBuffer(ctx, CL_MEM_READ_WRITE,
+        sizeof(double) * PAIR_CAPACITY, NULL, &err);
+    cl_mem pair_mi = clCreateBuffer(ctx, CL_MEM_READ_WRITE,
+        sizeof(double) * PAIR_CAPACITY, NULL, &err);
+    cl_mem pair_flags = clCreateBuffer(ctx, CL_MEM_READ_WRITE,
+        sizeof(uint32_t) * PAIR_CAPACITY, NULL, &err);
+
+    /* Pair bump allocator */
+    cl_mem pair_next_free = clCreateBuffer(ctx, CL_MEM_READ_WRITE | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint32_t), &zero, &err);
+
+    /* Section hash table */
+    cl_mem sht_keys = clCreateBuffer(ctx, CL_MEM_READ_WRITE,
+        sizeof(uint64_t) * SECTION_HT_CAPACITY, NULL, &err);
+    cl_mem sht_values = clCreateBuffer(ctx, CL_MEM_READ_WRITE,
+        sizeof(uint32_t) * SECTION_HT_CAPACITY, NULL, &err);
+
+    /* Section pool SoA */
+    cl_mem sec_word = clCreateBuffer(ctx, CL_MEM_READ_WRITE,
+        sizeof(uint32_t) * SECTION_CAPACITY, NULL, &err);
+    cl_mem sec_disjunct_hash = clCreateBuffer(ctx, CL_MEM_READ_WRITE,
+        sizeof(uint64_t) * SECTION_CAPACITY, NULL, &err);
+    cl_mem sec_count = clCreateBuffer(ctx, CL_MEM_READ_WRITE,
+        sizeof(double) * SECTION_CAPACITY, NULL, &err);
+
+    /* Section bump allocator */
+    cl_mem sec_next_free = clCreateBuffer(ctx, CL_MEM_READ_WRITE | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint32_t), &zero, &err);
+
+    /* Stats output */
+    cl_mem d_stats = clCreateBuffer(ctx, CL_MEM_WRITE_ONLY,
+        sizeof(uint32_t) * 3, NULL, &err);
+
+    /* Initialize hash tables to empty */
+    clEnqueueFillBuffer(queue, wht_keys, &pat_ff, 1, 0,
+        sizeof(uint64_t) * WORD_HT_CAPACITY, 0, NULL, NULL);
+    clEnqueueFillBuffer(queue, wht_values, &pat_ff, 1, 0,
+        sizeof(uint32_t) * WORD_HT_CAPACITY, 0, NULL, NULL);
+    clEnqueueFillBuffer(queue, pht_keys, &pat_ff, 1, 0,
+        sizeof(uint64_t) * PAIR_HT_CAPACITY, 0, NULL, NULL);
+    clEnqueueFillBuffer(queue, pht_values, &pat_ff, 1, 0,
+        sizeof(uint32_t) * PAIR_HT_CAPACITY, 0, NULL, NULL);
+    clEnqueueFillBuffer(queue, sht_keys, &pat_ff, 1, 0,
+        sizeof(uint64_t) * SECTION_HT_CAPACITY, 0, NULL, NULL);
+    clEnqueueFillBuffer(queue, sht_values, &pat_ff, 1, 0,
+        sizeof(uint32_t) * SECTION_HT_CAPACITY, 0, NULL, NULL);
+
+    /* Initialize pool arrays to 0 */
+    clEnqueueFillBuffer(queue, word_count, &pat_00, 1, 0,
+        sizeof(double) * WORD_CAPACITY, 0, NULL, NULL);
+    clEnqueueFillBuffer(queue, word_class_id, &pat_00, 1, 0,
+        sizeof(uint32_t) * WORD_CAPACITY, 0, NULL, NULL);
+    clEnqueueFillBuffer(queue, pair_count, &pat_00, 1, 0,
+        sizeof(double) * PAIR_CAPACITY, 0, NULL, NULL);
+    clEnqueueFillBuffer(queue, pair_mi, &pat_00, 1, 0,
+        sizeof(double) * PAIR_CAPACITY, 0, NULL, NULL);
+    clEnqueueFillBuffer(queue, pair_flags, &pat_00, 1, 0,
+        sizeof(uint32_t) * PAIR_CAPACITY, 0, NULL, NULL);
+    clEnqueueFillBuffer(queue, sec_count, &pat_00, 1, 0,
+        sizeof(double) * SECTION_CAPACITY, 0, NULL, NULL);
+    clFinish(queue);
+
+    /* Calculate total GPU memory */
+    size_t total_mem = 0;
+    total_mem += sizeof(uint64_t) * WORD_HT_CAPACITY;  /* wht_keys */
+    total_mem += sizeof(uint32_t) * WORD_HT_CAPACITY;  /* wht_values */
+    total_mem += sizeof(uint64_t) * WORD_CAPACITY;      /* word_name_hash */
+    total_mem += sizeof(double) * WORD_CAPACITY;        /* word_count */
+    total_mem += sizeof(uint32_t) * WORD_CAPACITY;      /* word_class_id */
+    total_mem += sizeof(uint64_t) * PAIR_HT_CAPACITY;   /* pht_keys */
+    total_mem += sizeof(uint32_t) * PAIR_HT_CAPACITY;   /* pht_values */
+    total_mem += sizeof(uint32_t) * PAIR_CAPACITY;      /* pair_word_a */
+    total_mem += sizeof(uint32_t) * PAIR_CAPACITY;      /* pair_word_b */
+    total_mem += sizeof(double) * PAIR_CAPACITY;        /* pair_count */
+    total_mem += sizeof(double) * PAIR_CAPACITY;        /* pair_mi */
+    total_mem += sizeof(uint32_t) * PAIR_CAPACITY;      /* pair_flags */
+    total_mem += sizeof(uint64_t) * SECTION_HT_CAPACITY;/* sht_keys */
+    total_mem += sizeof(uint32_t) * SECTION_HT_CAPACITY;/* sht_values */
+    total_mem += sizeof(uint32_t) * SECTION_CAPACITY;   /* sec_word */
+    total_mem += sizeof(uint64_t) * SECTION_CAPACITY;   /* sec_disjunct_hash */
+    total_mem += sizeof(double) * SECTION_CAPACITY;     /* sec_count */
+    printf("Total GPU memory: %zu MB\n\n", total_mem / (1024*1024));
+
+    /* ═══ TEST 1: Create words ═══ */
+
+    printf("--- Test 1: Create words ---\n");
+
+    const char* test_words[] = {
+        "the", "of", "and", "to", "a", "in", "was", "he", "she", "it",
+        "that", "is", "for", "his", "with", "her", "had", "not", "at", "on",
+        /* Duplicates to test dedup */
+        "the", "of", "and", "the", "he", "she"
+    };
+    int num_words_in = 26;
+    int num_unique_words = 20;
+
+    uint64_t* h_word_hashes = malloc(sizeof(uint64_t) * num_words_in);
+    for (int i = 0; i < num_words_in; i++) {
+        h_word_hashes[i] = hash_word(test_words[i]);
+    }
+
+    cl_mem d_word_hashes = clCreateBuffer(ctx, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint64_t) * num_words_in, h_word_hashes, &err);
+    uint32_t* h_word_indices = malloc(sizeof(uint32_t) * num_words_in);
+    cl_mem d_word_out = clCreateBuffer(ctx, CL_MEM_WRITE_ONLY,
+        sizeof(uint32_t) * num_words_in, NULL, &err);
+
+    cl_uint nw = num_words_in;
+    clSetKernelArg(k_word_foc, 0, sizeof(cl_mem), &wht_keys);
+    clSetKernelArg(k_word_foc, 1, sizeof(cl_mem), &wht_values);
+    clSetKernelArg(k_word_foc, 2, sizeof(cl_mem), &word_name_hash);
+    clSetKernelArg(k_word_foc, 3, sizeof(cl_mem), &word_count);
+    clSetKernelArg(k_word_foc, 4, sizeof(cl_mem), &word_class_id);
+    clSetKernelArg(k_word_foc, 5, sizeof(cl_mem), &word_next_free);
+    clSetKernelArg(k_word_foc, 6, sizeof(cl_mem), &d_word_hashes);
+    clSetKernelArg(k_word_foc, 7, sizeof(cl_mem), &d_word_out);
+    clSetKernelArg(k_word_foc, 8, sizeof(cl_uint), &nw);
+
+    double t0 = now_ms();
+    size_t gs = ((num_words_in + local_size - 1) / local_size) * local_size;
+    err = clEnqueueNDRangeKernel(queue, k_word_foc, 1, NULL,
+        &gs, &local_size, 0, NULL, NULL);
+    CL_CHECK(err, "enqueue word_foc");
+    clFinish(queue);
+    double t1 = now_ms();
+
+    clEnqueueReadBuffer(queue, d_word_out, CL_TRUE, 0,
+        sizeof(uint32_t) * num_words_in, h_word_indices, 0, NULL, NULL);
+
+    printf("  Created %d words (with %d dups) in %.2f ms\n",
+           num_words_in, num_words_in - num_unique_words, t1-t0);
+
+    /* Check dedup: "the" appears at indices 0, 20, 23 — should all get same pool index */
+    int dedup_ok = (h_word_indices[0] == h_word_indices[20] &&
+                    h_word_indices[0] == h_word_indices[23]);
+    printf("  'the' dedup: idx[0]=%u idx[20]=%u idx[23]=%u  %s\n",
+           h_word_indices[0], h_word_indices[20], h_word_indices[23],
+           dedup_ok ? "PASS" : "FAIL");
+
+    /* "he"=7, "he"=24 */
+    int dedup2 = (h_word_indices[7] == h_word_indices[24]);
+    printf("  'he'  dedup: idx[7]=%u idx[24]=%u  %s\n",
+           h_word_indices[7], h_word_indices[24],
+           dedup2 ? "PASS" : "FAIL");
+
+    /* Check pool stats */
+    clSetKernelArg(k_stats, 0, sizeof(cl_mem), &word_next_free);
+    clSetKernelArg(k_stats, 1, sizeof(cl_mem), &pair_next_free);
+    clSetKernelArg(k_stats, 2, sizeof(cl_mem), &sec_next_free);
+    clSetKernelArg(k_stats, 3, sizeof(cl_mem), &d_stats);
+
+    size_t one = 1;
+    clEnqueueNDRangeKernel(queue, k_stats, 1, NULL, &one, &one, 0, NULL, NULL);
+    uint32_t stats[3];
+    clEnqueueReadBuffer(queue, d_stats, CL_TRUE, 0, sizeof(stats), stats, 0, NULL, NULL);
+
+    printf("  Pool: %u words, %u pairs, %u sections\n", stats[0], stats[1], stats[2]);
+    printf("  %s\n\n", (stats[0] == num_unique_words) ? "PASS" : "FAIL");
+
+    /* ═══ TEST 2: Create pairs ═══ */
+
+    printf("--- Test 2: Create pairs ---\n");
+
+    /* Create pairs for a sentence: "the cat was on the mat"
+     * Words: the(0), cat(?), was(6), on(19), mat(?)
+     * We need to create cat and mat first */
+    uint64_t extra_hashes[2] = { hash_word("cat"), hash_word("mat") };
+    cl_mem d_extra = clCreateBuffer(ctx, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint64_t) * 2, extra_hashes, &err);
+    cl_mem d_extra_out = clCreateBuffer(ctx, CL_MEM_WRITE_ONLY,
+        sizeof(uint32_t) * 2, NULL, &err);
+
+    cl_uint n_extra = 2;
+    clSetKernelArg(k_word_foc, 6, sizeof(cl_mem), &d_extra);
+    clSetKernelArg(k_word_foc, 7, sizeof(cl_mem), &d_extra_out);
+    clSetKernelArg(k_word_foc, 8, sizeof(cl_uint), &n_extra);
+    gs = ((2 + local_size - 1) / local_size) * local_size;
+    clEnqueueNDRangeKernel(queue, k_word_foc, 1, NULL, &gs, &local_size, 0, NULL, NULL);
+    uint32_t extra_indices[2];
+    clEnqueueReadBuffer(queue, d_extra_out, CL_TRUE, 0,
+        sizeof(uint32_t) * 2, extra_indices, 0, NULL, NULL);
+
+    uint32_t idx_the = h_word_indices[0];
+    uint32_t idx_cat = extra_indices[0];
+    uint32_t idx_was = h_word_indices[6];
+    uint32_t idx_on  = h_word_indices[19];
+    uint32_t idx_mat = extra_indices[1];
+
+    printf("  Word indices: the=%u cat=%u was=%u on=%u mat=%u\n",
+           idx_the, idx_cat, idx_was, idx_on, idx_mat);
+
+    /* Create pairs within window=2: (the,cat) (the,was) (cat,was) (cat,on) (was,on) (was,the_2)
+     * Plus (on,the_2) (on,mat) (the_2,mat) */
+    int num_pairs_in = 9;
+    uint32_t h_pair_a[] = {idx_the, idx_the, idx_cat, idx_cat, idx_was, idx_was, idx_on, idx_on, idx_the};
+    uint32_t h_pair_b[] = {idx_cat, idx_was, idx_was, idx_on,  idx_on,  idx_the, idx_the,idx_mat,idx_mat};
+
+    /* Add duplicates to test dedup */
+    int num_with_dups = 12;
+    uint32_t h_pair_a2[12], h_pair_b2[12];
+    memcpy(h_pair_a2, h_pair_a, sizeof(uint32_t) * 9);
+    memcpy(h_pair_b2, h_pair_b, sizeof(uint32_t) * 9);
+    /* Duplicate first 3 pairs */
+    h_pair_a2[9]  = idx_the; h_pair_b2[9]  = idx_cat;
+    h_pair_a2[10] = idx_the; h_pair_b2[10] = idx_was;
+    h_pair_a2[11] = idx_cat; h_pair_b2[11] = idx_was;
+
+    cl_mem d_pair_a = clCreateBuffer(ctx, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint32_t) * num_with_dups, h_pair_a2, &err);
+    cl_mem d_pair_b = clCreateBuffer(ctx, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint32_t) * num_with_dups, h_pair_b2, &err);
+    cl_mem d_pair_out = clCreateBuffer(ctx, CL_MEM_WRITE_ONLY,
+        sizeof(uint32_t) * num_with_dups, NULL, &err);
+
+    cl_uint np = num_with_dups;
+    clSetKernelArg(k_pair_foc, 0, sizeof(cl_mem), &pht_keys);
+    clSetKernelArg(k_pair_foc, 1, sizeof(cl_mem), &pht_values);
+    clSetKernelArg(k_pair_foc, 2, sizeof(cl_mem), &pair_word_a);
+    clSetKernelArg(k_pair_foc, 3, sizeof(cl_mem), &pair_word_b);
+    clSetKernelArg(k_pair_foc, 4, sizeof(cl_mem), &pair_count);
+    clSetKernelArg(k_pair_foc, 5, sizeof(cl_mem), &pair_mi);
+    clSetKernelArg(k_pair_foc, 6, sizeof(cl_mem), &pair_flags);
+    clSetKernelArg(k_pair_foc, 7, sizeof(cl_mem), &pair_next_free);
+    clSetKernelArg(k_pair_foc, 8, sizeof(cl_mem), &d_pair_a);
+    clSetKernelArg(k_pair_foc, 9, sizeof(cl_mem), &d_pair_b);
+    clSetKernelArg(k_pair_foc, 10, sizeof(cl_mem), &d_pair_out);
+    clSetKernelArg(k_pair_foc, 11, sizeof(cl_uint), &np);
+
+    t0 = now_ms();
+    gs = ((num_with_dups + local_size - 1) / local_size) * local_size;
+    clEnqueueNDRangeKernel(queue, k_pair_foc, 1, NULL, &gs, &local_size, 0, NULL, NULL);
+    clFinish(queue);
+    t1 = now_ms();
+
+    uint32_t h_pair_indices[12];
+    clEnqueueReadBuffer(queue, d_pair_out, CL_TRUE, 0,
+        sizeof(uint32_t) * num_with_dups, h_pair_indices, 0, NULL, NULL);
+
+    /* Pair dedup: indices 0 and 9 should match (the,cat) */
+    int pair_dedup = (h_pair_indices[0] == h_pair_indices[9] &&
+                      h_pair_indices[1] == h_pair_indices[10] &&
+                      h_pair_indices[2] == h_pair_indices[11]);
+    printf("  Created %d pairs (3 dups) in %.2f ms\n", num_with_dups, t1-t0);
+    printf("  Pair dedup: %s\n", pair_dedup ? "PASS" : "FAIL");
+
+    /* Note: pair(the,was) and pair(was,the) should be the same (canonical order) */
+    int canon = (h_pair_indices[1] == h_pair_indices[5]);
+    printf("  Canonical order (the,was)==(was,the): idx=%u==%u  %s\n",
+           h_pair_indices[1], h_pair_indices[5], canon ? "PASS" : "FAIL");
+
+    clEnqueueNDRangeKernel(queue, k_stats, 1, NULL, &one, &one, 0, NULL, NULL);
+    clEnqueueReadBuffer(queue, d_stats, CL_TRUE, 0, sizeof(stats), stats, 0, NULL, NULL);
+    /* 9 pairs but (the,was) and (was,the) deduplicate to same, and
+     * (on,the) and (the,on) too. Let's count unique: */
+    printf("  Pool: %u words, %u pairs, %u sections\n", stats[0], stats[1], stats[2]);
+
+    int num_unique_pairs = stats[1];
+    printf("  %s\n\n", (num_unique_pairs > 0 && num_unique_pairs <= num_pairs_in) ? "PASS" : "FAIL");
+
+    /* ═══ TEST 3: Create sections ═══ */
+
+    printf("--- Test 3: Create sections ---\n");
+
+    /* Simulate sections: word + disjunct hash */
+    int num_sections = 8;
+    uint32_t h_sec_words[] = {idx_the, idx_the, idx_cat, idx_cat, idx_was, idx_was, idx_on, idx_mat};
+    uint64_t h_sec_dhash[] = {
+        0x1111111111111111ULL,  /* the: cat+ */
+        0x2222222222222222ULL,  /* the: was+ */
+        0x3333333333333333ULL,  /* cat: the- was+ */
+        0x4444444444444444ULL,  /* cat: was- on+ */
+        0x5555555555555555ULL,  /* was: cat- on+ */
+        0x2222222222222222ULL,  /* was: same disjunct as "the: was+" — different word, different section */
+        0x6666666666666666ULL,  /* on: was- the+ */
+        0x7777777777777777ULL,  /* mat: on- the+ */
+    };
+
+    cl_mem d_sec_w = clCreateBuffer(ctx, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint32_t) * num_sections, h_sec_words, &err);
+    cl_mem d_sec_d = clCreateBuffer(ctx, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint64_t) * num_sections, h_sec_dhash, &err);
+    cl_mem d_sec_out = clCreateBuffer(ctx, CL_MEM_WRITE_ONLY,
+        sizeof(uint32_t) * num_sections, NULL, &err);
+
+    cl_uint ns = num_sections;
+    clSetKernelArg(k_sec_foc, 0, sizeof(cl_mem), &sht_keys);
+    clSetKernelArg(k_sec_foc, 1, sizeof(cl_mem), &sht_values);
+    clSetKernelArg(k_sec_foc, 2, sizeof(cl_mem), &sec_word);
+    clSetKernelArg(k_sec_foc, 3, sizeof(cl_mem), &sec_disjunct_hash);
+    clSetKernelArg(k_sec_foc, 4, sizeof(cl_mem), &sec_count);
+    clSetKernelArg(k_sec_foc, 5, sizeof(cl_mem), &sec_next_free);
+    clSetKernelArg(k_sec_foc, 6, sizeof(cl_mem), &d_sec_w);
+    clSetKernelArg(k_sec_foc, 7, sizeof(cl_mem), &d_sec_d);
+    clSetKernelArg(k_sec_foc, 8, sizeof(cl_mem), &d_sec_out);
+    clSetKernelArg(k_sec_foc, 9, sizeof(cl_uint), &ns);
+
+    t0 = now_ms();
+    gs = ((num_sections + local_size - 1) / local_size) * local_size;
+    clEnqueueNDRangeKernel(queue, k_sec_foc, 1, NULL, &gs, &local_size, 0, NULL, NULL);
+    clFinish(queue);
+    t1 = now_ms();
+
+    uint32_t h_sec_indices[8];
+    clEnqueueReadBuffer(queue, d_sec_out, CL_TRUE, 0,
+        sizeof(uint32_t) * num_sections, h_sec_indices, 0, NULL, NULL);
+
+    printf("  Created %d sections in %.2f ms\n", num_sections, t1-t0);
+
+    /* Section(the, 0x222..) != Section(was, 0x222..) — different word, different section */
+    int sec_diff = (h_sec_indices[1] != h_sec_indices[5]);
+    printf("  Different word same disjunct = different section: %s\n",
+           sec_diff ? "PASS" : "FAIL");
+
+    clEnqueueNDRangeKernel(queue, k_stats, 1, NULL, &one, &one, 0, NULL, NULL);
+    clEnqueueReadBuffer(queue, d_stats, CL_TRUE, 0, sizeof(stats), stats, 0, NULL, NULL);
+    printf("  Pool: %u words, %u pairs, %u sections\n", stats[0], stats[1], stats[2]);
+    printf("  %s\n\n", (stats[2] == (uint32_t)num_sections) ? "PASS" : "FAIL");
+
+    /* ═══ TEST 4: Count pairs ═══ */
+
+    printf("--- Test 4: Count pairs (atomic double increment) ---\n");
+
+    /* Count pair 0 (the,cat) 100 times */
+    int count_n = 100;
+    uint32_t* h_count_indices = malloc(sizeof(uint32_t) * count_n);
+    for (int i = 0; i < count_n; i++) {
+        h_count_indices[i] = h_pair_indices[0]; /* (the,cat) */
+    }
+
+    cl_mem d_count_idx = clCreateBuffer(ctx, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint32_t) * count_n, h_count_indices, &err);
+
+    cl_uint cn = count_n;
+    clSetKernelArg(k_count_pairs, 0, sizeof(cl_mem), &pair_count);
+    clSetKernelArg(k_count_pairs, 1, sizeof(cl_mem), &pair_word_a);
+    clSetKernelArg(k_count_pairs, 2, sizeof(cl_mem), &pair_word_b);
+    clSetKernelArg(k_count_pairs, 3, sizeof(cl_mem), &word_count);
+    clSetKernelArg(k_count_pairs, 4, sizeof(cl_mem), &pair_flags);
+    clSetKernelArg(k_count_pairs, 5, sizeof(cl_mem), &d_count_idx);
+    clSetKernelArg(k_count_pairs, 6, sizeof(cl_uint), &cn);
+
+    t0 = now_ms();
+    gs = ((count_n + local_size - 1) / local_size) * local_size;
+    clEnqueueNDRangeKernel(queue, k_count_pairs, 1, NULL, &gs, &local_size, 0, NULL, NULL);
+    clFinish(queue);
+    t1 = now_ms();
+
+    /* Read back the pair count and word marginals */
+    double h_pair_c;
+    clEnqueueReadBuffer(queue, pair_count, CL_TRUE,
+        sizeof(double) * h_pair_indices[0], sizeof(double), &h_pair_c, 0, NULL, NULL);
+
+    double h_wc_the, h_wc_cat;
+    clEnqueueReadBuffer(queue, word_count, CL_TRUE,
+        sizeof(double) * idx_the, sizeof(double), &h_wc_the, 0, NULL, NULL);
+    clEnqueueReadBuffer(queue, word_count, CL_TRUE,
+        sizeof(double) * idx_cat, sizeof(double), &h_wc_cat, 0, NULL, NULL);
+
+    printf("  Counted pair(the,cat) %d times in %.2f ms\n", count_n, t1-t0);
+    printf("  pair_count = %.1f (expected %.1f)  %s\n",
+           h_pair_c, (double)count_n,
+           (fabs(h_pair_c - count_n) < 0.5) ? "PASS" : "FAIL");
+    printf("  word_count[the] = %.1f  word_count[cat] = %.1f  (both expect %.1f)  %s\n",
+           h_wc_the, h_wc_cat, (double)count_n,
+           (fabs(h_wc_the - count_n) < 0.5 && fabs(h_wc_cat - count_n) < 0.5)
+           ? "PASS" : "FAIL");
+
+    /* Check dirty flag */
+    uint32_t h_flag;
+    clEnqueueReadBuffer(queue, pair_flags, CL_TRUE,
+        sizeof(uint32_t) * h_pair_indices[0], sizeof(uint32_t), &h_flag, 0, NULL, NULL);
+    printf("  Dirty flag = %u (expected 1)  %s\n\n", h_flag, (h_flag == 1) ? "PASS" : "FAIL");
+
+    /* ═══ TEST 5: Count sections ═══ */
+
+    printf("--- Test 5: Count sections ---\n");
+
+    /* Count section 0 (the: cat+) 50 times */
+    int sec_count_n = 50;
+    uint32_t* h_sec_cnt_idx = malloc(sizeof(uint32_t) * sec_count_n);
+    for (int i = 0; i < sec_count_n; i++) {
+        h_sec_cnt_idx[i] = h_sec_indices[0];
+    }
+
+    cl_mem d_sec_cnt_idx = clCreateBuffer(ctx, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint32_t) * sec_count_n, h_sec_cnt_idx, &err);
+
+    cl_uint scn = sec_count_n;
+    clSetKernelArg(k_count_sec, 0, sizeof(cl_mem), &sec_count);
+    clSetKernelArg(k_count_sec, 1, sizeof(cl_mem), &d_sec_cnt_idx);
+    clSetKernelArg(k_count_sec, 2, sizeof(cl_uint), &scn);
+
+    t0 = now_ms();
+    gs = ((sec_count_n + local_size - 1) / local_size) * local_size;
+    clEnqueueNDRangeKernel(queue, k_count_sec, 1, NULL, &gs, &local_size, 0, NULL, NULL);
+    clFinish(queue);
+    t1 = now_ms();
+
+    double h_sec_c;
+    clEnqueueReadBuffer(queue, sec_count, CL_TRUE,
+        sizeof(double) * h_sec_indices[0], sizeof(double), &h_sec_c, 0, NULL, NULL);
+
+    printf("  Counted section 0 %d times in %.2f ms\n", sec_count_n, t1-t0);
+    printf("  sec_count = %.1f (expected %.1f)  %s\n\n",
+           h_sec_c, (double)sec_count_n,
+           (fabs(h_sec_c - sec_count_n) < 0.5) ? "PASS" : "FAIL");
+
+    /* ═══ TEST 6: Bulk performance ═══ */
+
+    printf("--- Test 6: Bulk performance ---\n");
+
+    /* Create 100K words */
+    int bulk_words = 100000;
+    uint64_t* h_bulk_hashes = malloc(sizeof(uint64_t) * bulk_words);
+    uint64_t rng = 0xDEADBEEFCAFEBABEULL;
+    for (int i = 0; i < bulk_words; i++) {
+        rng += 0x9E3779B97F4A7C15ULL;
+        uint64_t z = rng;
+        z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9ULL;
+        z = (z ^ (z >> 27)) * 0x94D049BB133111EBULL;
+        z = z ^ (z >> 31);
+        if (z == HT_EMPTY_KEY) z = 0;
+        h_bulk_hashes[i] = z;
+    }
+
+    cl_mem d_bulk = clCreateBuffer(ctx, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint64_t) * bulk_words, h_bulk_hashes, &err);
+    cl_mem d_bulk_out = clCreateBuffer(ctx, CL_MEM_WRITE_ONLY,
+        sizeof(uint32_t) * bulk_words, NULL, &err);
+
+    cl_uint bw = bulk_words;
+    clSetKernelArg(k_word_foc, 6, sizeof(cl_mem), &d_bulk);
+    clSetKernelArg(k_word_foc, 7, sizeof(cl_mem), &d_bulk_out);
+    clSetKernelArg(k_word_foc, 8, sizeof(cl_uint), &bw);
+
+    t0 = now_ms();
+    gs = ((bulk_words + local_size - 1) / local_size) * local_size;
+    clEnqueueNDRangeKernel(queue, k_word_foc, 1, NULL, &gs, &local_size, 0, NULL, NULL);
+    clFinish(queue);
+    t1 = now_ms();
+    printf("  100K words created in %.1f ms (%.1f M/sec)\n",
+           t1-t0, bulk_words / ((t1-t0) / 1000.0) / 1e6);
+
+    /* Create 1M pairs from random word indices */
+    int bulk_pairs = 1000000;
+    uint32_t* h_bulk_pa = malloc(sizeof(uint32_t) * bulk_pairs);
+    uint32_t* h_bulk_pb = malloc(sizeof(uint32_t) * bulk_pairs);
+    for (int i = 0; i < bulk_pairs; i++) {
+        rng += 0x9E3779B97F4A7C15ULL;
+        h_bulk_pa[i] = (uint32_t)(rng >> 32) % bulk_words;
+        h_bulk_pb[i] = (uint32_t)(rng & 0xFFFFFFFF) % bulk_words;
+    }
+
+    cl_mem d_bulk_pa = clCreateBuffer(ctx, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint32_t) * bulk_pairs, h_bulk_pa, &err);
+    cl_mem d_bulk_pb = clCreateBuffer(ctx, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint32_t) * bulk_pairs, h_bulk_pb, &err);
+    cl_mem d_bulk_po = clCreateBuffer(ctx, CL_MEM_WRITE_ONLY,
+        sizeof(uint32_t) * bulk_pairs, NULL, &err);
+
+    cl_uint bp = bulk_pairs;
+    clSetKernelArg(k_pair_foc, 8, sizeof(cl_mem), &d_bulk_pa);
+    clSetKernelArg(k_pair_foc, 9, sizeof(cl_mem), &d_bulk_pb);
+    clSetKernelArg(k_pair_foc, 10, sizeof(cl_mem), &d_bulk_po);
+    clSetKernelArg(k_pair_foc, 11, sizeof(cl_uint), &bp);
+
+    t0 = now_ms();
+    gs = ((bulk_pairs + local_size - 1) / local_size) * local_size;
+    clEnqueueNDRangeKernel(queue, k_pair_foc, 1, NULL, &gs, &local_size, 0, NULL, NULL);
+    clFinish(queue);
+    t1 = now_ms();
+    printf("  1M pairs created in %.1f ms (%.1f M/sec)\n",
+           t1-t0, bulk_pairs / ((t1-t0) / 1000.0) / 1e6);
+
+    /* Final stats */
+    clEnqueueNDRangeKernel(queue, k_stats, 1, NULL, &one, &one, 0, NULL, NULL);
+    clEnqueueReadBuffer(queue, d_stats, CL_TRUE, 0, sizeof(stats), stats, 0, NULL, NULL);
+    printf("  Final pool: %u words, %u pairs, %u sections\n\n", stats[0], stats[1], stats[2]);
+
+    printf("=== All tests complete ===\n");
+
+    /* ─── Cleanup ─── */
+
+    clReleaseMemObject(wht_keys);
+    clReleaseMemObject(wht_values);
+    clReleaseMemObject(word_name_hash);
+    clReleaseMemObject(word_count);
+    clReleaseMemObject(word_class_id);
+    clReleaseMemObject(word_next_free);
+    clReleaseMemObject(pht_keys);
+    clReleaseMemObject(pht_values);
+    clReleaseMemObject(pair_word_a);
+    clReleaseMemObject(pair_word_b);
+    clReleaseMemObject(pair_count);
+    clReleaseMemObject(pair_mi);
+    clReleaseMemObject(pair_flags);
+    clReleaseMemObject(pair_next_free);
+    clReleaseMemObject(sht_keys);
+    clReleaseMemObject(sht_values);
+    clReleaseMemObject(sec_word);
+    clReleaseMemObject(sec_disjunct_hash);
+    clReleaseMemObject(sec_count);
+    clReleaseMemObject(sec_next_free);
+    clReleaseMemObject(d_stats);
+    /* ... remaining temp buffers */
+    clReleaseKernel(k_word_foc);
+    clReleaseKernel(k_pair_foc);
+    clReleaseKernel(k_sec_foc);
+    clReleaseKernel(k_count_pairs);
+    clReleaseKernel(k_count_sec);
+    clReleaseKernel(k_stats);
+    clReleaseProgram(program);
+    clReleaseCommandQueue(queue);
+    clReleaseContext(ctx);
+
+    free(h_word_hashes);
+    free(h_word_indices);
+    free(h_count_indices);
+    free(h_sec_cnt_idx);
+    free(h_bulk_hashes);
+    free(h_bulk_pa);
+    free(h_bulk_pb);
+    free(combined);
+    free(ht_src);
+    free(as_src);
+
+    return 0;
+}

--- a/opencog/opencl/atomspace/test-hashtable.c
+++ b/opencog/opencl/atomspace/test-hashtable.c
@@ -1,0 +1,532 @@
+/*
+ * test-hashtable.c -- Standalone test for GPU hash table
+ *
+ * Compile: gcc -O2 -o test-hashtable test-hashtable.c -lOpenCL
+ * Run:     ./test-hashtable
+ *
+ * Tests:
+ *   1. Bulk insert 1M keys
+ *   2. Lookup all inserted keys (verify 100% hit)
+ *   3. Lookup non-existent keys (verify 100% miss)
+ *   4. Delete some keys, verify they're gone
+ *   5. Insert-or-increment (counting)
+ *   6. Iterate and verify count
+ *   7. Performance: inserts/sec and lookups/sec
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <time.h>
+#include <CL/cl.h>
+
+/* ─── Configuration ─── */
+
+/* Table capacity — must be power of 2.
+ * At 50% load factor, 4M slots supports 2M entries. */
+#define TABLE_CAPACITY  (4 * 1024 * 1024)  /* 4M slots */
+#define NUM_TEST_ITEMS  (1 * 1024 * 1024)  /* 1M test entries */
+
+#define HT_EMPTY_KEY    0xFFFFFFFFFFFFFFFFULL
+#define HT_EMPTY_VALUE  0xFFFFFFFFU
+
+/* ─── Error checking ─── */
+
+#define CL_CHECK(err, msg) do { \
+    if ((err) != CL_SUCCESS) { \
+        fprintf(stderr, "OpenCL error %d at %s:%d: %s\n", \
+                (err), __FILE__, __LINE__, (msg)); \
+        exit(1); \
+    } \
+} while(0)
+
+/* ─── Read kernel source ─── */
+
+char* read_file(const char* path, size_t* len)
+{
+    FILE* f = fopen(path, "r");
+    if (!f) { fprintf(stderr, "Cannot open %s\n", path); exit(1); }
+    fseek(f, 0, SEEK_END);
+    *len = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    char* buf = malloc(*len + 1);
+    fread(buf, 1, *len, f);
+    buf[*len] = '\0';
+    fclose(f);
+    return buf;
+}
+
+/* ─── Simple PRNG (splitmix64) ─── */
+
+static uint64_t rng_state = 0x12345678DEADBEEFULL;
+
+uint64_t next_random(void)
+{
+    rng_state += 0x9E3779B97F4A7C15ULL;
+    uint64_t z = rng_state;
+    z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9ULL;
+    z = (z ^ (z >> 27)) * 0x94D049BB133111EBULL;
+    return z ^ (z >> 31);
+}
+
+/* ─── Timing ─── */
+
+double now_ms(void)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return ts.tv_sec * 1000.0 + ts.tv_nsec / 1000000.0;
+}
+
+/* ─── Main ─── */
+
+int main(int argc, char** argv)
+{
+    cl_int err;
+
+    printf("=== GPU Hash Table Test ===\n");
+    printf("Table capacity: %d slots (%lu MB)\n",
+           TABLE_CAPACITY,
+           (unsigned long)(TABLE_CAPACITY * (sizeof(uint64_t) + sizeof(uint32_t))) / (1024*1024));
+    printf("Test items:     %d\n\n", NUM_TEST_ITEMS);
+
+    /* ─── OpenCL setup ─── */
+
+    cl_platform_id platform;
+    err = clGetPlatformIDs(1, &platform, NULL);
+    CL_CHECK(err, "clGetPlatformIDs");
+
+    cl_device_id device;
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device, NULL);
+    CL_CHECK(err, "clGetDeviceIDs");
+
+    /* Print device name */
+    char dev_name[256];
+    clGetDeviceInfo(device, CL_DEVICE_NAME, sizeof(dev_name), dev_name, NULL);
+    printf("GPU: %s\n", dev_name);
+
+    /* Check for int64 atomics */
+    char extensions[4096];
+    clGetDeviceInfo(device, CL_DEVICE_EXTENSIONS, sizeof(extensions), extensions, NULL);
+    if (!strstr(extensions, "cl_khr_int64_base_atomics")) {
+        fprintf(stderr, "ERROR: Device does not support cl_khr_int64_base_atomics\n");
+        return 1;
+    }
+    printf("cl_khr_int64_base_atomics: supported\n\n");
+
+    cl_context ctx = clCreateContext(NULL, 1, &device, NULL, NULL, &err);
+    CL_CHECK(err, "clCreateContext");
+
+    cl_command_queue queue = clCreateCommandQueue(ctx, device, 0, &err);
+    CL_CHECK(err, "clCreateCommandQueue");
+
+    /* ─── Build kernel ─── */
+
+    /* Find kernel source relative to this test file or in same dir */
+    const char* kernel_paths[] = {
+        "gpu-hashtable.cl",
+        "opencog/opencl/atomspace/gpu-hashtable.cl",
+        NULL
+    };
+    char* src = NULL;
+    size_t src_len = 0;
+    for (int i = 0; kernel_paths[i]; i++) {
+        FILE* f = fopen(kernel_paths[i], "r");
+        if (f) {
+            fclose(f);
+            src = read_file(kernel_paths[i], &src_len);
+            printf("Kernel source: %s\n", kernel_paths[i]);
+            break;
+        }
+    }
+    if (!src) {
+        fprintf(stderr, "Cannot find gpu-hashtable.cl\n");
+        return 1;
+    }
+
+    cl_program program = clCreateProgramWithSource(ctx, 1,
+        (const char**)&src, &src_len, &err);
+    CL_CHECK(err, "clCreateProgramWithSource");
+
+    err = clBuildProgram(program, 1, &device, "-cl-std=CL1.2", NULL, NULL);
+    if (err != CL_SUCCESS) {
+        char log[16384];
+        clGetProgramBuildInfo(program, device, CL_PROGRAM_BUILD_LOG,
+                              sizeof(log), log, NULL);
+        fprintf(stderr, "Build error:\n%s\n", log);
+        return 1;
+    }
+    printf("Kernel compiled successfully\n\n");
+
+    /* Create kernels */
+    cl_kernel k_insert = clCreateKernel(program, "ht_insert", &err);
+    CL_CHECK(err, "create ht_insert");
+    cl_kernel k_lookup = clCreateKernel(program, "ht_lookup", &err);
+    CL_CHECK(err, "create ht_lookup");
+    cl_kernel k_delete = clCreateKernel(program, "ht_delete", &err);
+    CL_CHECK(err, "create ht_delete");
+    cl_kernel k_inc = clCreateKernel(program, "ht_insert_or_increment", &err);
+    CL_CHECK(err, "create ht_insert_or_increment");
+    cl_kernel k_iter = clCreateKernel(program, "ht_iterate", &err);
+    CL_CHECK(err, "create ht_iterate");
+
+    /* ─── Allocate table on GPU ─── */
+
+    cl_ulong capacity = TABLE_CAPACITY;
+
+    cl_mem d_keys = clCreateBuffer(ctx, CL_MEM_READ_WRITE,
+        sizeof(uint64_t) * TABLE_CAPACITY, NULL, &err);
+    CL_CHECK(err, "alloc table keys");
+
+    cl_mem d_values = clCreateBuffer(ctx, CL_MEM_READ_WRITE,
+        sizeof(uint32_t) * TABLE_CAPACITY, NULL, &err);
+    CL_CHECK(err, "alloc table values");
+
+    /* Initialize table to empty (all 0xFF bytes) */
+    uint8_t pattern_ff = 0xFF;
+    err = clEnqueueFillBuffer(queue, d_keys, &pattern_ff, 1,
+        0, sizeof(uint64_t) * TABLE_CAPACITY, 0, NULL, NULL);
+    CL_CHECK(err, "fill table keys");
+    err = clEnqueueFillBuffer(queue, d_values, &pattern_ff, 1,
+        0, sizeof(uint32_t) * TABLE_CAPACITY, 0, NULL, NULL);
+    CL_CHECK(err, "fill table values");
+    clFinish(queue);
+
+    /* ─── Generate test data ─── */
+
+    uint64_t* h_keys   = malloc(sizeof(uint64_t) * NUM_TEST_ITEMS);
+    uint32_t* h_values = malloc(sizeof(uint32_t) * NUM_TEST_ITEMS);
+    uint32_t* h_results = malloc(sizeof(uint32_t) * NUM_TEST_ITEMS);
+
+    rng_state = 0x12345678DEADBEEFULL;
+    for (int i = 0; i < NUM_TEST_ITEMS; i++) {
+        uint64_t k = next_random();
+        /* Avoid sentinel key */
+        if (k == HT_EMPTY_KEY) k = 0;
+        h_keys[i]   = k;
+        h_values[i] = (uint32_t)(i & 0xFFFFFFFF);
+    }
+
+    /* Upload test data to GPU */
+    cl_mem d_in_keys = clCreateBuffer(ctx, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint64_t) * NUM_TEST_ITEMS, h_keys, &err);
+    CL_CHECK(err, "alloc input keys");
+    cl_mem d_in_values = clCreateBuffer(ctx, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint32_t) * NUM_TEST_ITEMS, h_values, &err);
+    CL_CHECK(err, "alloc input values");
+    cl_mem d_out_values = clCreateBuffer(ctx, CL_MEM_WRITE_ONLY,
+        sizeof(uint32_t) * NUM_TEST_ITEMS, NULL, &err);
+    CL_CHECK(err, "alloc output values");
+
+    size_t global_size = NUM_TEST_ITEMS;
+    size_t local_size = 256;
+    /* Round up global size to multiple of local size */
+    global_size = ((global_size + local_size - 1) / local_size) * local_size;
+
+    cl_uint num_items = NUM_TEST_ITEMS;
+
+    /* ═══ TEST 1: Bulk Insert ═══ */
+
+    printf("--- Test 1: Insert %d items ---\n", NUM_TEST_ITEMS);
+
+    clSetKernelArg(k_insert, 0, sizeof(cl_mem), &d_keys);
+    clSetKernelArg(k_insert, 1, sizeof(cl_mem), &d_values);
+    clSetKernelArg(k_insert, 2, sizeof(cl_ulong), &capacity);
+    clSetKernelArg(k_insert, 3, sizeof(cl_mem), &d_in_keys);
+    clSetKernelArg(k_insert, 4, sizeof(cl_mem), &d_in_values);
+    clSetKernelArg(k_insert, 5, sizeof(cl_uint), &num_items);
+
+    double t0 = now_ms();
+    err = clEnqueueNDRangeKernel(queue, k_insert, 1, NULL,
+        &global_size, &local_size, 0, NULL, NULL);
+    CL_CHECK(err, "enqueue insert");
+    clFinish(queue);
+    double t1 = now_ms();
+
+    printf("  Inserted %d items in %.1f ms (%.1f M keys/sec)\n",
+           NUM_TEST_ITEMS, t1-t0, NUM_TEST_ITEMS / ((t1-t0) / 1000.0) / 1e6);
+
+    /* ═══ TEST 2: Lookup all (should all hit) ═══ */
+
+    printf("--- Test 2: Lookup %d items (expect all found) ---\n", NUM_TEST_ITEMS);
+
+    clSetKernelArg(k_lookup, 0, sizeof(cl_mem), &d_keys);
+    clSetKernelArg(k_lookup, 1, sizeof(cl_mem), &d_values);
+    clSetKernelArg(k_lookup, 2, sizeof(cl_ulong), &capacity);
+    clSetKernelArg(k_lookup, 3, sizeof(cl_mem), &d_in_keys);
+    clSetKernelArg(k_lookup, 4, sizeof(cl_mem), &d_out_values);
+    clSetKernelArg(k_lookup, 5, sizeof(cl_uint), &num_items);
+
+    t0 = now_ms();
+    err = clEnqueueNDRangeKernel(queue, k_lookup, 1, NULL,
+        &global_size, &local_size, 0, NULL, NULL);
+    CL_CHECK(err, "enqueue lookup");
+    clFinish(queue);
+    t1 = now_ms();
+
+    /* Read back results */
+    err = clEnqueueReadBuffer(queue, d_out_values, CL_TRUE, 0,
+        sizeof(uint32_t) * NUM_TEST_ITEMS, h_results, 0, NULL, NULL);
+    CL_CHECK(err, "read lookup results");
+
+    int hits = 0, misses = 0, wrong = 0;
+    for (int i = 0; i < NUM_TEST_ITEMS; i++) {
+        if (h_results[i] == HT_EMPTY_VALUE)
+            misses++;
+        else if (h_results[i] == h_values[i])
+            hits++;
+        else
+            wrong++;
+    }
+
+    printf("  Lookup in %.1f ms (%.1f M keys/sec)\n",
+           t1-t0, NUM_TEST_ITEMS / ((t1-t0) / 1000.0) / 1e6);
+    printf("  Hits: %d  Misses: %d  Wrong: %d\n", hits, misses, wrong);
+    printf("  %s\n\n", (hits == NUM_TEST_ITEMS && misses == 0 && wrong == 0)
+           ? "PASS" : "FAIL");
+
+    /* ═══ TEST 3: Lookup non-existent keys (should all miss) ═══ */
+
+    printf("--- Test 3: Lookup %d non-existent keys ---\n", NUM_TEST_ITEMS);
+
+    /* Generate different keys */
+    rng_state = 0xABCDABCDABCDABCDULL;
+    uint64_t* h_miss_keys = malloc(sizeof(uint64_t) * NUM_TEST_ITEMS);
+    for (int i = 0; i < NUM_TEST_ITEMS; i++) {
+        uint64_t k = next_random();
+        if (k == HT_EMPTY_KEY) k = 0;
+        h_miss_keys[i] = k;
+    }
+
+    cl_mem d_miss_keys = clCreateBuffer(ctx, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint64_t) * NUM_TEST_ITEMS, h_miss_keys, &err);
+    CL_CHECK(err, "alloc miss keys");
+
+    clSetKernelArg(k_lookup, 3, sizeof(cl_mem), &d_miss_keys);
+
+    t0 = now_ms();
+    err = clEnqueueNDRangeKernel(queue, k_lookup, 1, NULL,
+        &global_size, &local_size, 0, NULL, NULL);
+    CL_CHECK(err, "enqueue miss lookup");
+    clFinish(queue);
+    t1 = now_ms();
+
+    err = clEnqueueReadBuffer(queue, d_out_values, CL_TRUE, 0,
+        sizeof(uint32_t) * NUM_TEST_ITEMS, h_results, 0, NULL, NULL);
+    CL_CHECK(err, "read miss results");
+
+    misses = 0;
+    for (int i = 0; i < NUM_TEST_ITEMS; i++) {
+        if (h_results[i] == HT_EMPTY_VALUE) misses++;
+    }
+
+    printf("  Lookup in %.1f ms\n", t1-t0);
+    printf("  Misses: %d / %d\n", misses, NUM_TEST_ITEMS);
+    printf("  %s\n\n", (misses == NUM_TEST_ITEMS) ? "PASS" : "FAIL");
+
+    /* ═══ TEST 4: Delete first 1000 keys, verify ═══ */
+
+    int num_delete = 1000;
+    printf("--- Test 4: Delete %d keys ---\n", num_delete);
+
+    cl_mem d_del_keys = clCreateBuffer(ctx, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint64_t) * num_delete, h_keys, &err);
+    CL_CHECK(err, "alloc del keys");
+
+    cl_uint nd = num_delete;
+    clSetKernelArg(k_delete, 0, sizeof(cl_mem), &d_keys);
+    clSetKernelArg(k_delete, 1, sizeof(cl_mem), &d_values);
+    clSetKernelArg(k_delete, 2, sizeof(cl_ulong), &capacity);
+    clSetKernelArg(k_delete, 3, sizeof(cl_mem), &d_del_keys);
+    clSetKernelArg(k_delete, 4, sizeof(cl_uint), &nd);
+
+    size_t del_global = ((num_delete + local_size - 1) / local_size) * local_size;
+    err = clEnqueueNDRangeKernel(queue, k_delete, 1, NULL,
+        &del_global, &local_size, 0, NULL, NULL);
+    CL_CHECK(err, "enqueue delete");
+    clFinish(queue);
+
+    /* Lookup deleted keys — should miss */
+    cl_mem d_del_query = clCreateBuffer(ctx, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint64_t) * num_delete, h_keys, &err);
+    cl_mem d_del_out = clCreateBuffer(ctx, CL_MEM_WRITE_ONLY,
+        sizeof(uint32_t) * num_delete, NULL, &err);
+
+    clSetKernelArg(k_lookup, 3, sizeof(cl_mem), &d_del_query);
+    clSetKernelArg(k_lookup, 4, sizeof(cl_mem), &d_del_out);
+    clSetKernelArg(k_lookup, 5, sizeof(cl_uint), &nd);
+
+    err = clEnqueueNDRangeKernel(queue, k_lookup, 1, NULL,
+        &del_global, &local_size, 0, NULL, NULL);
+    CL_CHECK(err, "enqueue del verify");
+    clFinish(queue);
+
+    uint32_t* h_del_results = malloc(sizeof(uint32_t) * num_delete);
+    err = clEnqueueReadBuffer(queue, d_del_out, CL_TRUE, 0,
+        sizeof(uint32_t) * num_delete, h_del_results, 0, NULL, NULL);
+
+    int del_gone = 0;
+    for (int i = 0; i < num_delete; i++) {
+        if (h_del_results[i] == HT_EMPTY_VALUE) del_gone++;
+    }
+    printf("  Deleted keys returning empty: %d / %d\n", del_gone, num_delete);
+    printf("  %s\n\n", (del_gone == num_delete) ? "PASS" : "FAIL");
+
+    /* ═══ TEST 5: Insert-or-increment ═══ */
+
+    printf("--- Test 5: Insert-or-increment (counting) ---\n");
+
+    /* Re-initialize table: keys to 0xFF (empty), values to 0 (for counting) */
+    err = clEnqueueFillBuffer(queue, d_keys, &pattern_ff, 1,
+        0, sizeof(uint64_t) * TABLE_CAPACITY, 0, NULL, NULL);
+    CL_CHECK(err, "refill keys");
+    uint8_t pattern_00 = 0x00;
+    err = clEnqueueFillBuffer(queue, d_values, &pattern_00, 1,
+        0, sizeof(uint32_t) * TABLE_CAPACITY, 0, NULL, NULL);
+    CL_CHECK(err, "refill values to 0");
+    clFinish(queue);
+
+    /* Insert same 100 keys 1000 times each = 100K operations */
+    int inc_unique = 100;
+    int inc_repeats = 1000;
+    int inc_total = inc_unique * inc_repeats;
+    uint64_t* h_inc_keys = malloc(sizeof(uint64_t) * inc_total);
+
+    rng_state = 0xFEEDFACECAFEBABEULL;
+    uint64_t base_keys[100];
+    for (int i = 0; i < inc_unique; i++) {
+        base_keys[i] = next_random();
+        if (base_keys[i] == HT_EMPTY_KEY) base_keys[i] = 0;
+    }
+    for (int r = 0; r < inc_repeats; r++) {
+        for (int i = 0; i < inc_unique; i++) {
+            h_inc_keys[r * inc_unique + i] = base_keys[i];
+        }
+    }
+
+    cl_mem d_inc_keys = clCreateBuffer(ctx, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint64_t) * inc_total, h_inc_keys, &err);
+    CL_CHECK(err, "alloc inc keys");
+
+    cl_uint inc_n = inc_total;
+    clSetKernelArg(k_inc, 0, sizeof(cl_mem), &d_keys);
+    clSetKernelArg(k_inc, 1, sizeof(cl_mem), &d_values);
+    clSetKernelArg(k_inc, 2, sizeof(cl_ulong), &capacity);
+    clSetKernelArg(k_inc, 3, sizeof(cl_mem), &d_inc_keys);
+    clSetKernelArg(k_inc, 4, sizeof(cl_uint), &inc_n);
+
+    size_t inc_global = ((inc_total + local_size - 1) / local_size) * local_size;
+    t0 = now_ms();
+    err = clEnqueueNDRangeKernel(queue, k_inc, 1, NULL,
+        &inc_global, &local_size, 0, NULL, NULL);
+    CL_CHECK(err, "enqueue increment");
+    clFinish(queue);
+    t1 = now_ms();
+    printf("  %d increments in %.1f ms\n", inc_total, t1-t0);
+
+    /* Lookup the 100 keys, verify counts = 1000 (first insert = 1, then 999 increments) */
+    cl_mem d_inc_query = clCreateBuffer(ctx, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint64_t) * inc_unique, base_keys, &err);
+    cl_mem d_inc_out = clCreateBuffer(ctx, CL_MEM_WRITE_ONLY,
+        sizeof(uint32_t) * inc_unique, NULL, &err);
+    cl_uint inc_u = inc_unique;
+
+    clSetKernelArg(k_lookup, 3, sizeof(cl_mem), &d_inc_query);
+    clSetKernelArg(k_lookup, 4, sizeof(cl_mem), &d_inc_out);
+    clSetKernelArg(k_lookup, 5, sizeof(cl_uint), &inc_u);
+
+    size_t inc_q_global = ((inc_unique + local_size - 1) / local_size) * local_size;
+    err = clEnqueueNDRangeKernel(queue, k_lookup, 1, NULL,
+        &inc_q_global, &local_size, 0, NULL, NULL);
+    clFinish(queue);
+
+    uint32_t* h_inc_results = malloc(sizeof(uint32_t) * inc_unique);
+    clEnqueueReadBuffer(queue, d_inc_out, CL_TRUE, 0,
+        sizeof(uint32_t) * inc_unique, h_inc_results, 0, NULL, NULL);
+
+    int correct_counts = 0;
+    for (int i = 0; i < inc_unique; i++) {
+        if (h_inc_results[i] == (uint32_t)inc_repeats) correct_counts++;
+        else if (i < 5) printf("  key %d: expected %d got %u\n", i, inc_repeats, h_inc_results[i]);
+    }
+    printf("  Correct counts (%d): %d / %d\n", inc_repeats, correct_counts, inc_unique);
+    printf("  %s\n\n", (correct_counts == inc_unique) ? "PASS" : "FAIL");
+
+    /* ═══ TEST 6: Iterate ═══ */
+
+    printf("--- Test 6: Iterate (collect non-empty entries) ---\n");
+
+    cl_mem d_iter_keys = clCreateBuffer(ctx, CL_MEM_WRITE_ONLY,
+        sizeof(uint64_t) * inc_unique * 2, NULL, &err);
+    cl_mem d_iter_values = clCreateBuffer(ctx, CL_MEM_WRITE_ONLY,
+        sizeof(uint32_t) * inc_unique * 2, NULL, &err);
+    uint32_t zero = 0;
+    cl_mem d_iter_count = clCreateBuffer(ctx, CL_MEM_READ_WRITE | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint32_t), &zero, &err);
+    cl_uint max_out = inc_unique * 2;
+
+    clSetKernelArg(k_iter, 0, sizeof(cl_mem), &d_keys);
+    clSetKernelArg(k_iter, 1, sizeof(cl_mem), &d_values);
+    clSetKernelArg(k_iter, 2, sizeof(cl_ulong), &capacity);
+    clSetKernelArg(k_iter, 3, sizeof(cl_mem), &d_iter_keys);
+    clSetKernelArg(k_iter, 4, sizeof(cl_mem), &d_iter_values);
+    clSetKernelArg(k_iter, 5, sizeof(cl_mem), &d_iter_count);
+    clSetKernelArg(k_iter, 6, sizeof(cl_uint), &max_out);
+
+    size_t iter_global = ((TABLE_CAPACITY + local_size - 1) / local_size) * local_size;
+    t0 = now_ms();
+    err = clEnqueueNDRangeKernel(queue, k_iter, 1, NULL,
+        &iter_global, &local_size, 0, NULL, NULL);
+    CL_CHECK(err, "enqueue iterate");
+    clFinish(queue);
+    t1 = now_ms();
+
+    uint32_t iter_count;
+    clEnqueueReadBuffer(queue, d_iter_count, CL_TRUE, 0,
+        sizeof(uint32_t), &iter_count, 0, NULL, NULL);
+    printf("  Iterated %u M slots in %.1f ms, found %u entries\n",
+           TABLE_CAPACITY / (1024*1024), t1-t0, iter_count);
+    printf("  Expected: %d entries\n", inc_unique);
+    printf("  %s\n\n", (iter_count == (uint32_t)inc_unique) ? "PASS" : "FAIL");
+
+    /* ═══ Summary ═══ */
+
+    printf("=== All tests complete ===\n");
+
+    /* ─── Cleanup ─── */
+
+    clReleaseMemObject(d_keys);
+    clReleaseMemObject(d_values);
+    clReleaseMemObject(d_in_keys);
+    clReleaseMemObject(d_in_values);
+    clReleaseMemObject(d_out_values);
+    clReleaseMemObject(d_miss_keys);
+    clReleaseMemObject(d_del_keys);
+    clReleaseMemObject(d_del_query);
+    clReleaseMemObject(d_del_out);
+    clReleaseMemObject(d_inc_keys);
+    clReleaseMemObject(d_inc_query);
+    clReleaseMemObject(d_inc_out);
+    clReleaseMemObject(d_iter_keys);
+    clReleaseMemObject(d_iter_values);
+    clReleaseMemObject(d_iter_count);
+    clReleaseKernel(k_insert);
+    clReleaseKernel(k_lookup);
+    clReleaseKernel(k_delete);
+    clReleaseKernel(k_inc);
+    clReleaseKernel(k_iter);
+    clReleaseProgram(program);
+    clReleaseCommandQueue(queue);
+    clReleaseContext(ctx);
+    free(h_keys);
+    free(h_values);
+    free(h_results);
+    free(h_miss_keys);
+    free(h_del_results);
+    free(h_inc_keys);
+    free(h_inc_results);
+    free(src);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary

GPU-resident data structures for the AtomSpace pipeline — the foundation layer that all subsequent kernels build on.

- **gpu-hashtable.cl** — Lock-free hash table using FNV-1a hashing with CAS-based insert. Provides O(1) atom identity lookups on GPU with linear probing for collision handling and support for concurrent writers.
- **gpu-atomspace.cl** — SoA (Structure of Arrays) pool management for `WordPool`, `PairPool`, and `SectionPool`. Atomic allocation via `gpu_pool_alloc()`, capacity tracking, and efficient GPU-side memory layout.

## Pipeline Position

This is **Phase 0-1** of the GPU-native AtomSpace pipeline:

```
[Phase 0-1: Hash Table + Pools] ← THIS PR (foundation — merge first)
 Phase 2-3: Counting + MI      (#4, depends on this)
 Phase 4-5: Sections + Cosine  (#5, depends on this)
 Phase 6:   Substitution       (#6, depends on this)
```

> **Note:** PRs #4, #5, and #6 reference the pool structs (`WordPool`, `PairPool`, `SectionPool`) and hash table defined here. This PR should be merged first. Each subsequent PR adds only new kernel files — no merge conflicts between them.

## Files

| File | Lines | Description |
|------|-------|-------------|
| `gpu-hashtable.cl` | 303 | Lock-free FNV-1a hash table kernel |
| `gpu-atomspace.cl` | 407 | Word/Pair/Section pool management |
| `test-hashtable.c` | 532 | Hash table unit tests |
| `test-atomspace.c` | 739 | Pool management unit tests |
| `.gitignore` | 8 | Ignore compiled test binaries |

## Building & Testing

```bash
cd opencog/opencl/atomspace

# Hash table tests
gcc -o test-hashtable test-hashtable.c -lOpenCL -lm
./test-hashtable

# Pool management tests
gcc -o test-atomspace test-atomspace.c -lOpenCL -lm
./test-atomspace
```

## Relationship to Prior Work

Builds on PR #2 (binary caching + dispatch thread build), which was merged as `2a9c544`. These kernels benefit from the binary caching infrastructure for faster program load times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)