### PR TITLE
GPU-native AtomSpace Phase 2-3: pair counting + MI computation

### DIFF
--- a/opencog/opencl/atomspace/gpu-counting.cl
+++ b/opencog/opencl/atomspace/gpu-counting.cl
@@ -1,0 +1,296 @@
+/*
+ * gpu-counting.cl -- Sentence processing and pair counting on GPU
+ *
+ * Takes batches of sentences (as word pool indices), generates all
+ * word pairs within a sliding window, finds-or-creates each pair
+ * in the pair pool, and atomically increments counts.
+ *
+ * This replaces cl-l0-count-pairs! from corpus-learning.scm.
+ *
+ * Appended after gpu-hashtable.cl and gpu-atomspace.cl at load time.
+ */
+
+/* ═══════════════════════════════════════════════════════════════
+ *  SENTENCE PAIR COUNTING
+ *
+ *  One thread per word position. Each thread generates up to
+ *  WINDOW_SIZE pairs with subsequent words in the same sentence.
+ *  For each pair: find-or-create + atomic count increment.
+ * ═══════════════════════════════════════════════════════════════ */
+
+/*
+ * Process a batch of sentences: count all word pairs within window.
+ *
+ * Work assignment: one thread per word position across all sentences.
+ * Thread i handles the word at flat_words[i], generating pairs with
+ * the next WINDOW_SIZE words in the same sentence.
+ *
+ * Args:
+ *   flat_words       - all sentences concatenated [total_words]
+ *   sent_offsets      - start index of each sentence [num_sentences]
+ *   sent_lengths      - length of each sentence [num_sentences]
+ *   num_sentences     - number of sentences in batch
+ *   total_words       - total words across all sentences
+ *   window_size       - pair window (typically 6)
+ *
+ *   -- Pair pool + hash table --
+ *   pht_keys, pht_values  - pair hash table
+ *   pair_word_a, pair_word_b, pair_count, pair_mi, pair_flags
+ *   pair_next_free
+ *
+ *   -- Word pool (marginals) --
+ *   word_count
+ *
+ *   -- Global counter --
+ *   total_pair_count  - total pairs counted (atomic)
+ */
+__kernel void count_sentence_pairs(
+    __global const uint*     flat_words,
+    __global const uint*     sent_offsets,
+    __global const uint*     sent_lengths,
+    const uint               num_sentences,
+    const uint               total_words,
+    const uint               window_size,
+    /* pair hash table */
+    __global volatile ulong* pht_keys,
+    __global volatile uint*  pht_values,
+    /* pair pool SoA */
+    __global uint*           pair_word_a,
+    __global uint*           pair_word_b,
+    __global volatile double* pair_count,
+    __global double*         pair_mi,
+    __global volatile uint*  pair_flags,
+    __global volatile uint*  pair_next_free,
+    /* word pool */
+    __global volatile double* word_count,
+    /* global counter */
+    __global volatile uint*  total_pair_count)
+{
+    uint tid = get_global_id(0);
+    if (tid >= total_words) return;
+
+    uint word_i = flat_words[tid];
+
+    /* Find which sentence this word belongs to (linear scan — sentences
+     * are small, typically <100 per batch, so this is fast) */
+    uint sent_idx = 0;
+    for (uint s = 0; s < num_sentences; s++) {
+        if (tid >= sent_offsets[s] &&
+            tid < sent_offsets[s] + sent_lengths[s]) {
+            sent_idx = s;
+            break;
+        }
+    }
+
+    uint sent_start = sent_offsets[sent_idx];
+    uint sent_len   = sent_lengths[sent_idx];
+    uint pos_in_sent = tid - sent_start;
+
+    /* Generate pairs with subsequent words within window */
+    uint max_j = min(pos_in_sent + window_size, sent_len - 1);
+
+    for (uint j = pos_in_sent + 1; j <= max_j; j++)
+    {
+        uint word_j = flat_words[sent_start + j];
+
+        /* Skip self-pairs */
+        if (word_i == word_j) continue;
+
+        /* ── Find or create pair ── */
+        uint lo = min(word_i, word_j);
+        uint hi = max(word_i, word_j);
+        ulong key = ((ulong)lo << 32) | (ulong)hi;
+
+        ulong ht_cap = PAIR_HT_CAPACITY;
+        ulong mask = ht_cap - 1;
+        ulong slot = ht_hash(key) & mask;
+        uint pair_idx = HT_EMPTY_VALUE;
+
+        for (uint probe = 0; probe < HT_MAX_PROBES; probe++)
+        {
+            ulong prev = atom_cmpxchg(&pht_keys[slot], HT_EMPTY_KEY, key);
+
+            if (prev == HT_EMPTY_KEY)
+            {
+                /* New pair — allocate from pool */
+                uint idx = atomic_add(pair_next_free, 1U);
+                if (idx < PAIR_CAPACITY) {
+                    pair_word_a[idx] = lo;
+                    pair_word_b[idx] = hi;
+                    pair_count[idx] = 0.0;
+                    pair_mi[idx] = 0.0;
+                    pair_flags[idx] = 0;
+                    mem_fence(CLK_GLOBAL_MEM_FENCE);
+                    pht_values[slot] = idx;
+                    pair_idx = idx;
+                }
+                break;
+            }
+            if (prev == key)
+            {
+                /* Existing pair — spin for value */
+                uint val = pht_values[slot];
+                while (val == HT_EMPTY_VALUE) {
+                    val = pht_values[slot];
+                }
+                pair_idx = val;
+                break;
+            }
+
+            slot = (slot + 1) & mask;
+        }
+
+        if (pair_idx == HT_EMPTY_VALUE) continue;
+
+        /* ── Increment counts ── */
+
+        /* Pair count */
+        atomic_add_double(&pair_count[pair_idx], 1.0);
+
+        /* Word marginals (both words) */
+        atomic_add_double(&word_count[word_i], 1.0);
+        atomic_add_double(&word_count[word_j], 1.0);
+
+        /* Mark dirty */
+        pair_flags[pair_idx] = 1;
+
+        /* Total count */
+        atomic_add(total_pair_count, 1U);
+    }
+}
+
+/* ═══════════════════════════════════════════════════════════════
+ *  BATCH SENTENCE PROCESSING — BINARY SEARCH VARIANT
+ *
+ *  For large batches (1000+ sentences), uses binary search instead
+ *  of linear scan to find which sentence a word belongs to.
+ * ═══════════════════════════════════════════════════════════════ */
+
+__kernel void count_sentence_pairs_large(
+    __global const uint*     flat_words,
+    __global const uint*     sent_offsets,
+    __global const uint*     sent_lengths,
+    const uint               num_sentences,
+    const uint               total_words,
+    const uint               window_size,
+    __global volatile ulong* pht_keys,
+    __global volatile uint*  pht_values,
+    __global uint*           pair_word_a,
+    __global uint*           pair_word_b,
+    __global volatile double* pair_count,
+    __global double*         pair_mi,
+    __global volatile uint*  pair_flags,
+    __global volatile uint*  pair_next_free,
+    __global volatile double* word_count,
+    __global volatile uint*  total_pair_count)
+{
+    uint tid = get_global_id(0);
+    if (tid >= total_words) return;
+
+    uint word_i = flat_words[tid];
+
+    /* Binary search for sentence index */
+    uint lo_s = 0, hi_s = num_sentences;
+    while (lo_s < hi_s) {
+        uint mid = (lo_s + hi_s) / 2;
+        if (sent_offsets[mid] + sent_lengths[mid] <= tid)
+            lo_s = mid + 1;
+        else
+            hi_s = mid;
+    }
+    uint sent_idx = lo_s;
+    if (sent_idx >= num_sentences) return;
+
+    uint sent_start = sent_offsets[sent_idx];
+    uint sent_len   = sent_lengths[sent_idx];
+    uint pos_in_sent = tid - sent_start;
+
+    /* Verify we're actually in this sentence */
+    if (pos_in_sent >= sent_len) return;
+
+    uint max_j = min(pos_in_sent + window_size, sent_len - 1);
+
+    for (uint j = pos_in_sent + 1; j <= max_j; j++)
+    {
+        uint word_j = flat_words[sent_start + j];
+        if (word_i == word_j) continue;
+
+        uint lo = min(word_i, word_j);
+        uint hi = max(word_i, word_j);
+        ulong key = ((ulong)lo << 32) | (ulong)hi;
+
+        ulong ht_cap = PAIR_HT_CAPACITY;
+        ulong mask = ht_cap - 1;
+        ulong slot = ht_hash(key) & mask;
+        uint pair_idx = HT_EMPTY_VALUE;
+
+        for (uint probe = 0; probe < HT_MAX_PROBES; probe++)
+        {
+            ulong prev = atom_cmpxchg(&pht_keys[slot], HT_EMPTY_KEY, key);
+
+            if (prev == HT_EMPTY_KEY)
+            {
+                uint idx = atomic_add(pair_next_free, 1U);
+                if (idx < PAIR_CAPACITY) {
+                    pair_word_a[idx] = lo;
+                    pair_word_b[idx] = hi;
+                    pair_count[idx] = 0.0;
+                    pair_mi[idx] = 0.0;
+                    pair_flags[idx] = 0;
+                    mem_fence(CLK_GLOBAL_MEM_FENCE);
+                    pht_values[slot] = idx;
+                    pair_idx = idx;
+                }
+                break;
+            }
+            if (prev == key)
+            {
+                uint val = pht_values[slot];
+                while (val == HT_EMPTY_VALUE) {
+                    val = pht_values[slot];
+                }
+                pair_idx = val;
+                break;
+            }
+
+            slot = (slot + 1) & mask;
+        }
+
+        if (pair_idx == HT_EMPTY_VALUE) continue;
+
+        atomic_add_double(&pair_count[pair_idx], 1.0);
+        atomic_add_double(&word_count[word_i], 1.0);
+        atomic_add_double(&word_count[word_j], 1.0);
+        pair_flags[pair_idx] = 1;
+        atomic_add(total_pair_count, 1U);
+    }
+}
+
+/* ═══════════════════════════════════════════════════════════════
+ *  READBACK: Dump pair data for verification
+ *
+ *  Reads pair pool entries into flat output arrays.
+ * ═══════════════════════════════════════════════════════════════ */
+
+__kernel void read_pairs(
+    __global const uint*   pair_word_a,
+    __global const uint*   pair_word_b,
+    __global const double* pair_count,
+    __global const double* pair_mi,
+    __global const uint*   pair_flags,
+    __global uint*         out_word_a,
+    __global uint*         out_word_b,
+    __global double*       out_count,
+    __global double*       out_mi,
+    __global uint*         out_flags,
+    const uint             num_pairs)
+{
+    uint tid = get_global_id(0);
+    if (tid >= num_pairs) return;
+
+    out_word_a[tid] = pair_word_a[tid];
+    out_word_b[tid] = pair_word_b[tid];
+    out_count[tid]  = pair_count[tid];
+    out_mi[tid]     = pair_mi[tid];
+    out_flags[tid]  = pair_flags[tid];
+}

--- a/opencog/opencl/atomspace/gpu-mi.cl
+++ b/opencog/opencl/atomspace/gpu-mi.cl
@@ -1,0 +1,224 @@
+/*
+ * gpu-mi.cl -- MI computation on GPU-resident atom pools
+ *
+ * Computes mutual information directly from pair pool and word pool
+ * buffers already resident in GPU memory. No CPU↔GPU data transfer
+ * needed — the counting kernel (gpu-counting.cl) populates the same
+ * buffers that this kernel reads.
+ *
+ * MI(x,y) = log2(count(x,y) * N / (count(x,*) * count(*,y)))
+ *
+ * Where:
+ *   count(x,y) = pair_count[pair_idx]
+ *   count(x,*) = word_count[pair_word_a[pair_idx]]  (left marginal)
+ *   count(*,y) = word_count[pair_word_b[pair_idx]]  (right marginal)
+ *   N          = total pair observations (passed as scalar arg)
+ *
+ * Appended after gpu-hashtable.cl, gpu-atomspace.cl, gpu-counting.cl
+ * at load time.
+ */
+
+/* ═══════════════════════════════════════════════════════════════
+ *  COMPUTE MI FOR ALL PAIRS
+ *
+ *  One thread per pair in the pool. Reads pair count and word
+ *  marginals directly from GPU-resident SoA arrays.
+ *
+ *  Pairs with count < 1 get MI = 0.
+ * ═══════════════════════════════════════════════════════════════ */
+
+__kernel void compute_mi_resident(
+    __global const double* pair_count,
+    __global const uint*   pair_word_a,
+    __global const uint*   pair_word_b,
+    __global double*       pair_mi,
+    __global const double* word_count,
+    const double           n_total,
+    const uint             num_pairs)
+{
+    uint tid = get_global_id(0);
+    if (tid >= num_pairs) return;
+
+    double count = pair_count[tid];
+    if (count < 1.0) {
+        pair_mi[tid] = 0.0;
+        return;
+    }
+
+    uint wa = pair_word_a[tid];
+    uint wb = pair_word_b[tid];
+    double left  = word_count[wa];
+    double right = word_count[wb];
+
+    /* MI = log2(count * N / (left * right))
+     *    = (ln(count) + ln(N) - ln(left) - ln(right)) / ln(2) */
+    double eps = 1e-10;
+    left  = fmax(left, eps);
+    right = fmax(right, eps);
+    double n = fmax(n_total, eps);
+
+    double log2_factor = 1.4426950408889634;
+    double mi = (log(count) + log(n) - log(left) - log(right)) * log2_factor;
+
+    pair_mi[tid] = mi;
+}
+
+/* ═══════════════════════════════════════════════════════════════
+ *  COMPUTE MI FOR DIRTY PAIRS ONLY
+ *
+ *  Same as above but only processes pairs where flags == 1.
+ *  Clears the dirty flag after computation.
+ *
+ *  Use this for incremental MI updates after new sentences
+ *  are counted — avoids recomputing all 2M+ pairs.
+ * ═══════════════════════════════════════════════════════════════ */
+
+__kernel void compute_mi_dirty(
+    __global const double*  pair_count,
+    __global const uint*    pair_word_a,
+    __global const uint*    pair_word_b,
+    __global double*        pair_mi,
+    __global volatile uint* pair_flags,
+    __global const double*  word_count,
+    const double            n_total,
+    const uint              num_pairs)
+{
+    uint tid = get_global_id(0);
+    if (tid >= num_pairs) return;
+
+    if (pair_flags[tid] != 1) return;
+
+    double count = pair_count[tid];
+    if (count < 1.0) {
+        pair_mi[tid] = 0.0;
+        pair_flags[tid] = 0;
+        return;
+    }
+
+    uint wa = pair_word_a[tid];
+    uint wb = pair_word_b[tid];
+    double left  = word_count[wa];
+    double right = word_count[wb];
+
+    double eps = 1e-10;
+    left  = fmax(left, eps);
+    right = fmax(right, eps);
+    double n = fmax(n_total, eps);
+
+    double log2_factor = 1.4426950408889634;
+    double mi = (log(count) + log(n) - log(left) - log(right)) * log2_factor;
+
+    pair_mi[tid] = mi;
+    pair_flags[tid] = 0;
+}
+
+/* ═══════════════════════════════════════════════════════════════
+ *  MI STATISTICS
+ *
+ *  Count pairs by MI value. Useful for diagnostics and
+ *  determining warm-start thresholds.
+ *
+ *  Outputs (all single-uint atomic counters, init to 0):
+ *    count_nonzero     — pairs with count > 0
+ *    count_positive_mi — pairs with MI > 0
+ *    count_above_thresh — pairs with MI > threshold
+ * ═══════════════════════════════════════════════════════════════ */
+
+__kernel void mi_stats(
+    __global const double* pair_mi,
+    __global const double* pair_count,
+    const uint             num_pairs,
+    const double           threshold,
+    __global volatile uint* count_nonzero,
+    __global volatile uint* count_positive_mi,
+    __global volatile uint* count_above_thresh)
+{
+    uint tid = get_global_id(0);
+    if (tid >= num_pairs) return;
+
+    double cnt = pair_count[tid];
+    if (cnt < 0.5) return;
+
+    atomic_add(count_nonzero, 1U);
+
+    double mi = pair_mi[tid];
+    if (mi > 0.0)
+        atomic_add(count_positive_mi, 1U);
+    if (mi > threshold)
+        atomic_add(count_above_thresh, 1U);
+}
+
+/* ═══════════════════════════════════════════════════════════════
+ *  MI THRESHOLD FILTER
+ *
+ *  Compact pairs above a MI threshold into contiguous output
+ *  arrays. Returns (pair_index, mi_value) for each passing pair.
+ *
+ *  Use cases:
+ *    - Warm-start bootstrap (only load high-MI pairs)
+ *    - Building neighbor index for cosine similarity
+ *    - Exporting significant pairs for visualization
+ *
+ *  out_count must be initialized to 0 before kernel launch.
+ * ═══════════════════════════════════════════════════════════════ */
+
+__kernel void mi_filter(
+    __global const double* pair_mi,
+    __global const double* pair_count,
+    const uint             num_pairs,
+    const double           mi_threshold,
+    __global uint*         out_pair_indices,
+    __global double*       out_mi_values,
+    __global volatile uint* out_count,
+    const uint             max_output)
+{
+    uint tid = get_global_id(0);
+    if (tid >= num_pairs) return;
+
+    double cnt = pair_count[tid];
+    double mi  = pair_mi[tid];
+
+    if (cnt > 0.5 && mi > mi_threshold) {
+        uint idx = atomic_add(out_count, 1U);
+        if (idx < max_output) {
+            out_pair_indices[idx] = tid;
+            out_mi_values[idx] = mi;
+        }
+    }
+}
+
+/* ═══════════════════════════════════════════════════════════════
+ *  READBACK: Dump pair data with MI for verification
+ *
+ *  Extended version of read_pairs from gpu-counting.cl that
+ *  also includes word indices and MI values.
+ * ═══════════════════════════════════════════════════════════════ */
+
+__kernel void read_pairs_with_mi(
+    __global const uint*   pair_word_a,
+    __global const uint*   pair_word_b,
+    __global const double* pair_count,
+    __global const double* pair_mi,
+    __global const uint*   pair_flags,
+    __global const double* word_count,
+    __global uint*         out_word_a,
+    __global uint*         out_word_b,
+    __global double*       out_count,
+    __global double*       out_mi,
+    __global double*       out_left_marginal,
+    __global double*       out_right_marginal,
+    const uint             num_pairs)
+{
+    uint tid = get_global_id(0);
+    if (tid >= num_pairs) return;
+
+    uint wa = pair_word_a[tid];
+    uint wb = pair_word_b[tid];
+
+    out_word_a[tid]         = wa;
+    out_word_b[tid]         = wb;
+    out_count[tid]          = pair_count[tid];
+    out_mi[tid]             = pair_mi[tid];
+    out_left_marginal[tid]  = word_count[wa];
+    out_right_marginal[tid] = word_count[wb];
+}

--- a/opencog/opencl/atomspace/test-counting.c
+++ b/opencog/opencl/atomspace/test-counting.c
@@ -1,0 +1,720 @@
+/*
+ * test-counting.c -- Test GPU sentence counting kernel
+ *
+ * Compile: gcc -O2 -o test-counting test-counting.c -lOpenCL -lm
+ * Run:     ./test-counting
+ *
+ * Tests:
+ *   1. Simple sentence pair counting (window=2, exact verification)
+ *   2. Multi-sentence batch (verify no cross-boundary pairs)
+ *   3. Read pairs kernel (readback verification)
+ *   4. Binary search variant (count_sentence_pairs_large)
+ *   5. Benchmark: 1000 sentences with window=6
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <math.h>
+#include <time.h>
+#include <CL/cl.h>
+
+/* ─── Pool capacities ─── */
+
+#define WORD_CAPACITY        (128 * 1024)
+#define PAIR_CAPACITY        (4 * 1024 * 1024)
+#define SECTION_CAPACITY     (1024 * 1024)
+#define WORD_HT_CAPACITY     (256 * 1024)
+#define PAIR_HT_CAPACITY     (8 * 1024 * 1024)
+#define SECTION_HT_CAPACITY  (2 * 1024 * 1024)
+
+#define HT_EMPTY_KEY    0xFFFFFFFFFFFFFFFFULL
+#define HT_EMPTY_VALUE  0xFFFFFFFFU
+
+/* ─── Error checking ─── */
+
+#define CL_CHECK(err, msg) do { \
+    if ((err) != CL_SUCCESS) { \
+        fprintf(stderr, "OpenCL error %d at %s:%d: %s\n", \
+                (err), __FILE__, __LINE__, (msg)); \
+        exit(1); \
+    } \
+} while(0)
+
+/* ─── Read file ─── */
+
+char* read_file(const char* path, size_t* len)
+{
+    FILE* f = fopen(path, "r");
+    if (!f) { fprintf(stderr, "Cannot open %s\n", path); exit(1); }
+    fseek(f, 0, SEEK_END);
+    *len = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    char* buf = malloc(*len + 1);
+    size_t n = fread(buf, 1, *len, f);
+    buf[n] = '\0';
+    *len = n;
+    fclose(f);
+    return buf;
+}
+
+/* ─── Timing ─── */
+
+double now_ms(void)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return ts.tv_sec * 1000.0 + ts.tv_nsec / 1000000.0;
+}
+
+/* ─── Helper: reset pair pool and counters ─── */
+
+void reset_pools(cl_command_queue queue,
+                 cl_mem pht_keys, cl_mem pht_values,
+                 cl_mem pair_count, cl_mem pair_mi, cl_mem pair_flags,
+                 cl_mem word_count,
+                 cl_mem pair_next_free, cl_mem total_pair_count)
+{
+    uint8_t pat_ff = 0xFF;
+    uint8_t pat_00 = 0x00;
+    uint32_t zero = 0;
+
+    clEnqueueFillBuffer(queue, pht_keys, &pat_ff, 1, 0,
+        sizeof(uint64_t) * PAIR_HT_CAPACITY, 0, NULL, NULL);
+    clEnqueueFillBuffer(queue, pht_values, &pat_ff, 1, 0,
+        sizeof(uint32_t) * PAIR_HT_CAPACITY, 0, NULL, NULL);
+    clEnqueueFillBuffer(queue, pair_count, &pat_00, 1, 0,
+        sizeof(double) * PAIR_CAPACITY, 0, NULL, NULL);
+    clEnqueueFillBuffer(queue, pair_mi, &pat_00, 1, 0,
+        sizeof(double) * PAIR_CAPACITY, 0, NULL, NULL);
+    clEnqueueFillBuffer(queue, pair_flags, &pat_00, 1, 0,
+        sizeof(uint32_t) * PAIR_CAPACITY, 0, NULL, NULL);
+    clEnqueueFillBuffer(queue, word_count, &pat_00, 1, 0,
+        sizeof(double) * WORD_CAPACITY, 0, NULL, NULL);
+    clEnqueueWriteBuffer(queue, pair_next_free, CL_FALSE, 0,
+        sizeof(uint32_t), &zero, 0, NULL, NULL);
+    clEnqueueWriteBuffer(queue, total_pair_count, CL_FALSE, 0,
+        sizeof(uint32_t), &zero, 0, NULL, NULL);
+    clFinish(queue);
+}
+
+/* ─── Main ─── */
+
+int main(int argc, char** argv)
+{
+    cl_int err;
+    int pass_count = 0, fail_count = 0;
+
+    printf("=== GPU Sentence Counting Test ===\n\n");
+
+    /* ─── OpenCL setup ─── */
+
+    cl_platform_id platform;
+    err = clGetPlatformIDs(1, &platform, NULL);
+    CL_CHECK(err, "platform");
+
+    cl_device_id device;
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device, NULL);
+    CL_CHECK(err, "device");
+
+    char dev_name[256];
+    clGetDeviceInfo(device, CL_DEVICE_NAME, sizeof(dev_name), dev_name, NULL);
+    printf("GPU: %s\n", dev_name);
+
+    cl_context ctx = clCreateContext(NULL, 1, &device, NULL, NULL, &err);
+    CL_CHECK(err, "context");
+
+    cl_command_queue queue = clCreateCommandQueue(ctx, device, 0, &err);
+    CL_CHECK(err, "queue");
+
+    /* ─── Load and concatenate kernel sources ─── */
+
+    size_t ht_len, as_len, ct_len;
+    char* ht_src = read_file("gpu-hashtable.cl", &ht_len);
+    char* as_src = read_file("gpu-atomspace.cl", &as_len);
+    char* ct_src = read_file("gpu-counting.cl", &ct_len);
+
+    size_t total_len = ht_len + 1 + as_len + 1 + ct_len;
+    char* combined = malloc(total_len + 1);
+    memcpy(combined, ht_src, ht_len);
+    combined[ht_len] = '\n';
+    memcpy(combined + ht_len + 1, as_src, as_len);
+    combined[ht_len + 1 + as_len] = '\n';
+    memcpy(combined + ht_len + 1 + as_len + 1, ct_src, ct_len);
+    combined[total_len] = '\0';
+
+    cl_program program = clCreateProgramWithSource(ctx, 1,
+        (const char**)&combined, &total_len, &err);
+    CL_CHECK(err, "create program");
+
+    char build_opts[512];
+    snprintf(build_opts, sizeof(build_opts),
+        "-cl-std=CL1.2 "
+        "-DWORD_CAPACITY=%d "
+        "-DPAIR_CAPACITY=%d "
+        "-DSECTION_CAPACITY=%d "
+        "-DWORD_HT_CAPACITY=%d "
+        "-DPAIR_HT_CAPACITY=%d "
+        "-DSECTION_HT_CAPACITY=%d",
+        WORD_CAPACITY, PAIR_CAPACITY, SECTION_CAPACITY,
+        WORD_HT_CAPACITY, PAIR_HT_CAPACITY, SECTION_HT_CAPACITY);
+
+    err = clBuildProgram(program, 1, &device, build_opts, NULL, NULL);
+    if (err != CL_SUCCESS) {
+        char log[16384];
+        clGetProgramBuildInfo(program, device, CL_PROGRAM_BUILD_LOG,
+                              sizeof(log), log, NULL);
+        fprintf(stderr, "Build error:\n%s\n", log);
+        return 1;
+    }
+    printf("Kernels compiled successfully\n\n");
+
+    /* ─── Create kernels ─── */
+
+    cl_kernel k_count = clCreateKernel(program, "count_sentence_pairs", &err);
+    CL_CHECK(err, "kernel count_sentence_pairs");
+    cl_kernel k_count_large = clCreateKernel(program, "count_sentence_pairs_large", &err);
+    CL_CHECK(err, "kernel count_sentence_pairs_large");
+    cl_kernel k_read = clCreateKernel(program, "read_pairs", &err);
+    CL_CHECK(err, "kernel read_pairs");
+
+    size_t local_size = 256;
+
+    /* ─── Allocate GPU buffers ─── */
+
+    printf("Allocating GPU buffers...\n");
+    uint32_t zero = 0;
+
+    /* Pair hash table */
+    cl_mem pht_keys = clCreateBuffer(ctx, CL_MEM_READ_WRITE,
+        sizeof(uint64_t) * PAIR_HT_CAPACITY, NULL, &err);
+    CL_CHECK(err, "pht_keys");
+    cl_mem pht_values = clCreateBuffer(ctx, CL_MEM_READ_WRITE,
+        sizeof(uint32_t) * PAIR_HT_CAPACITY, NULL, &err);
+    CL_CHECK(err, "pht_values");
+
+    /* Pair pool SoA */
+    cl_mem pair_word_a = clCreateBuffer(ctx, CL_MEM_READ_WRITE,
+        sizeof(uint32_t) * PAIR_CAPACITY, NULL, &err);
+    cl_mem pair_word_b = clCreateBuffer(ctx, CL_MEM_READ_WRITE,
+        sizeof(uint32_t) * PAIR_CAPACITY, NULL, &err);
+    cl_mem pair_count = clCreateBuffer(ctx, CL_MEM_READ_WRITE,
+        sizeof(double) * PAIR_CAPACITY, NULL, &err);
+    cl_mem pair_mi = clCreateBuffer(ctx, CL_MEM_READ_WRITE,
+        sizeof(double) * PAIR_CAPACITY, NULL, &err);
+    cl_mem pair_flags = clCreateBuffer(ctx, CL_MEM_READ_WRITE,
+        sizeof(uint32_t) * PAIR_CAPACITY, NULL, &err);
+
+    /* Pair bump allocator */
+    cl_mem pair_next_free = clCreateBuffer(ctx, CL_MEM_READ_WRITE | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint32_t), &zero, &err);
+
+    /* Word count array (marginals) — used directly by counting kernel */
+    cl_mem word_count = clCreateBuffer(ctx, CL_MEM_READ_WRITE,
+        sizeof(double) * WORD_CAPACITY, NULL, &err);
+
+    /* Total pair count (global atomic counter) */
+    cl_mem total_pair_count = clCreateBuffer(ctx, CL_MEM_READ_WRITE | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint32_t), &zero, &err);
+
+    /* Initial reset */
+    reset_pools(queue, pht_keys, pht_values, pair_count, pair_mi,
+                pair_flags, word_count, pair_next_free, total_pair_count);
+
+    printf("GPU buffers ready\n\n");
+
+    /* ═══════════════════════════════════════════════════════════════
+     *  TEST 1: Simple sentence pair counting
+     *
+     *  Sentence: word indices [0, 1, 2, 3] — 4 words
+     *  Window = 2
+     *
+     *  Expected pairs (one thread per word position):
+     *    pos 0: (0,1), (0,2)
+     *    pos 1: (1,2), (1,3)
+     *    pos 2: (2,3)
+     *    pos 3: —
+     *
+     *  = 5 unique pairs, 5 count events
+     *  Word marginals: word0=2, word1=3, word2=3, word3=2
+     * ═══════════════════════════════════════════════════════════════ */
+
+    printf("--- Test 1: Simple sentence (window=2) ---\n");
+
+    uint32_t sent1_words[] = {0, 1, 2, 3};
+    uint32_t sent1_offset = 0;
+    uint32_t sent1_length = 4;
+    cl_uint num_sentences = 1;
+    cl_uint tw = 4;
+    cl_uint window_size = 2;
+
+    cl_mem d_flat_words = clCreateBuffer(ctx, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint32_t) * tw, sent1_words, &err);
+    cl_mem d_sent_offsets = clCreateBuffer(ctx, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint32_t), &sent1_offset, &err);
+    cl_mem d_sent_lengths = clCreateBuffer(ctx, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint32_t), &sent1_length, &err);
+
+    /* Set all 16 kernel args for count_sentence_pairs */
+    clSetKernelArg(k_count, 0, sizeof(cl_mem), &d_flat_words);
+    clSetKernelArg(k_count, 1, sizeof(cl_mem), &d_sent_offsets);
+    clSetKernelArg(k_count, 2, sizeof(cl_mem), &d_sent_lengths);
+    clSetKernelArg(k_count, 3, sizeof(cl_uint), &num_sentences);
+    clSetKernelArg(k_count, 4, sizeof(cl_uint), &tw);
+    clSetKernelArg(k_count, 5, sizeof(cl_uint), &window_size);
+    clSetKernelArg(k_count, 6, sizeof(cl_mem), &pht_keys);
+    clSetKernelArg(k_count, 7, sizeof(cl_mem), &pht_values);
+    clSetKernelArg(k_count, 8, sizeof(cl_mem), &pair_word_a);
+    clSetKernelArg(k_count, 9, sizeof(cl_mem), &pair_word_b);
+    clSetKernelArg(k_count, 10, sizeof(cl_mem), &pair_count);
+    clSetKernelArg(k_count, 11, sizeof(cl_mem), &pair_mi);
+    clSetKernelArg(k_count, 12, sizeof(cl_mem), &pair_flags);
+    clSetKernelArg(k_count, 13, sizeof(cl_mem), &pair_next_free);
+    clSetKernelArg(k_count, 14, sizeof(cl_mem), &word_count);
+    clSetKernelArg(k_count, 15, sizeof(cl_mem), &total_pair_count);
+
+    double t0 = now_ms();
+    size_t gs = ((tw + local_size - 1) / local_size) * local_size;
+    err = clEnqueueNDRangeKernel(queue, k_count, 1, NULL,
+        &gs, &local_size, 0, NULL, NULL);
+    CL_CHECK(err, "enqueue count");
+    clFinish(queue);
+    double t1 = now_ms();
+
+    /* Read back results */
+    uint32_t h_num_pairs;
+    clEnqueueReadBuffer(queue, pair_next_free, CL_TRUE, 0,
+        sizeof(uint32_t), &h_num_pairs, 0, NULL, NULL);
+
+    uint32_t h_total;
+    clEnqueueReadBuffer(queue, total_pair_count, CL_TRUE, 0,
+        sizeof(uint32_t), &h_total, 0, NULL, NULL);
+
+    /* Read word marginals */
+    double wc[4];
+    clEnqueueReadBuffer(queue, word_count, CL_TRUE, 0,
+        sizeof(double) * 4, wc, 0, NULL, NULL);
+
+    printf("  Pairs created: %u (expected 5)\n", h_num_pairs);
+    printf("  Total count events: %u (expected 5)\n", h_total);
+    printf("  Word marginals: [0]=%.0f [1]=%.0f [2]=%.0f [3]=%.0f\n",
+           wc[0], wc[1], wc[2], wc[3]);
+    printf("    Expected:     [0]=2  [1]=3  [2]=3  [3]=2\n");
+    printf("  Time: %.2f ms\n", t1 - t0);
+
+    int t1_pass = (h_num_pairs == 5) && (h_total == 5) &&
+                  (fabs(wc[0] - 2.0) < 0.5) && (fabs(wc[1] - 3.0) < 0.5) &&
+                  (fabs(wc[2] - 3.0) < 0.5) && (fabs(wc[3] - 2.0) < 0.5);
+    printf("  %s\n\n", t1_pass ? "PASS" : "FAIL");
+    if (t1_pass) pass_count++; else fail_count++;
+
+    /* ═══════════════════════════════════════════════════════════════
+     *  TEST 2: Multi-sentence batch
+     *
+     *  Sentence 1: [0, 1, 2, 3]  — 4 words (same as test 1)
+     *  Sentence 2: [4, 5, 6]     — 3 words (disjoint vocabulary)
+     *
+     *  flat_words  = [0, 1, 2, 3, 4, 5, 6]
+     *  sent_offsets = [0, 4]
+     *  sent_lengths = [4, 3]
+     *
+     *  Window = 2:
+     *    Sentence 1: (0,1) (0,2) (1,2) (1,3) (2,3) = 5 pairs
+     *    Sentence 2: (4,5) (4,6) (5,6)              = 3 pairs
+     *    Total: 8 unique pairs, 8 count events
+     *
+     *  KEY: no cross-boundary pairs (e.g., no (3,4) pair)
+     * ═══════════════════════════════════════════════════════════════ */
+
+    printf("--- Test 2: Multi-sentence batch (window=2) ---\n");
+
+    reset_pools(queue, pht_keys, pht_values, pair_count, pair_mi,
+                pair_flags, word_count, pair_next_free, total_pair_count);
+
+    uint32_t multi_words[] = {0, 1, 2, 3, 4, 5, 6};
+    uint32_t multi_offsets[] = {0, 4};
+    uint32_t multi_lengths[] = {4, 3};
+    cl_uint multi_ns = 2;
+    cl_uint multi_tw = 7;
+
+    clReleaseMemObject(d_flat_words);
+    clReleaseMemObject(d_sent_offsets);
+    clReleaseMemObject(d_sent_lengths);
+
+    d_flat_words = clCreateBuffer(ctx, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint32_t) * multi_tw, multi_words, &err);
+    d_sent_offsets = clCreateBuffer(ctx, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint32_t) * multi_ns, multi_offsets, &err);
+    d_sent_lengths = clCreateBuffer(ctx, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint32_t) * multi_ns, multi_lengths, &err);
+
+    /* Update sentence-specific args (6-15 stay same) */
+    clSetKernelArg(k_count, 0, sizeof(cl_mem), &d_flat_words);
+    clSetKernelArg(k_count, 1, sizeof(cl_mem), &d_sent_offsets);
+    clSetKernelArg(k_count, 2, sizeof(cl_mem), &d_sent_lengths);
+    clSetKernelArg(k_count, 3, sizeof(cl_uint), &multi_ns);
+    clSetKernelArg(k_count, 4, sizeof(cl_uint), &multi_tw);
+    clSetKernelArg(k_count, 5, sizeof(cl_uint), &window_size);
+
+    t0 = now_ms();
+    gs = ((multi_tw + local_size - 1) / local_size) * local_size;
+    err = clEnqueueNDRangeKernel(queue, k_count, 1, NULL,
+        &gs, &local_size, 0, NULL, NULL);
+    CL_CHECK(err, "enqueue count multi");
+    clFinish(queue);
+    t1 = now_ms();
+
+    clEnqueueReadBuffer(queue, pair_next_free, CL_TRUE, 0,
+        sizeof(uint32_t), &h_num_pairs, 0, NULL, NULL);
+    clEnqueueReadBuffer(queue, total_pair_count, CL_TRUE, 0,
+        sizeof(uint32_t), &h_total, 0, NULL, NULL);
+
+    printf("  Pairs created: %u (expected 8)\n", h_num_pairs);
+    printf("  Total count events: %u (expected 8)\n", h_total);
+    printf("  Time: %.2f ms\n", t1 - t0);
+
+    /* Verify no cross-boundary pairs exist.
+     * Words 0-3 belong to sentence 1, words 4-6 to sentence 2.
+     * No pair should have one word from each sentence. */
+    uint32_t* h_pa = malloc(sizeof(uint32_t) * h_num_pairs);
+    uint32_t* h_pb = malloc(sizeof(uint32_t) * h_num_pairs);
+    clEnqueueReadBuffer(queue, pair_word_a, CL_TRUE, 0,
+        sizeof(uint32_t) * h_num_pairs, h_pa, 0, NULL, NULL);
+    clEnqueueReadBuffer(queue, pair_word_b, CL_TRUE, 0,
+        sizeof(uint32_t) * h_num_pairs, h_pb, 0, NULL, NULL);
+
+    int cross_boundary = 0;
+    for (uint32_t i = 0; i < h_num_pairs; i++) {
+        int a_sent = (h_pa[i] <= 3) ? 1 : 2;
+        int b_sent = (h_pb[i] <= 3) ? 1 : 2;
+        if (a_sent != b_sent) {
+            cross_boundary++;
+            printf("  CROSS-BOUNDARY: pair(%u, %u)\n", h_pa[i], h_pb[i]);
+        }
+    }
+    printf("  Cross-boundary pairs: %d (expected 0)\n", cross_boundary);
+
+    int t2_pass = (h_num_pairs == 8) && (h_total == 8) && (cross_boundary == 0);
+    printf("  %s\n\n", t2_pass ? "PASS" : "FAIL");
+    if (t2_pass) pass_count++; else fail_count++;
+
+    free(h_pa);
+    free(h_pb);
+
+    /* ═══════════════════════════════════════════════════════════════
+     *  TEST 3: Read pairs (readback kernel)
+     *
+     *  Uses the read_pairs kernel to copy pair data from the pool
+     *  into output arrays. Verifies all pairs from Test 2 have
+     *  count=1 and dirty flag=1.
+     * ═══════════════════════════════════════════════════════════════ */
+
+    printf("--- Test 3: Read pairs (readback verification) ---\n");
+
+    cl_mem d_out_wa = clCreateBuffer(ctx, CL_MEM_WRITE_ONLY,
+        sizeof(uint32_t) * h_num_pairs, NULL, &err);
+    cl_mem d_out_wb = clCreateBuffer(ctx, CL_MEM_WRITE_ONLY,
+        sizeof(uint32_t) * h_num_pairs, NULL, &err);
+    cl_mem d_out_cnt = clCreateBuffer(ctx, CL_MEM_WRITE_ONLY,
+        sizeof(double) * h_num_pairs, NULL, &err);
+    cl_mem d_out_mi = clCreateBuffer(ctx, CL_MEM_WRITE_ONLY,
+        sizeof(double) * h_num_pairs, NULL, &err);
+    cl_mem d_out_flags = clCreateBuffer(ctx, CL_MEM_WRITE_ONLY,
+        sizeof(uint32_t) * h_num_pairs, NULL, &err);
+
+    cl_uint np = h_num_pairs;
+    clSetKernelArg(k_read, 0, sizeof(cl_mem), &pair_word_a);
+    clSetKernelArg(k_read, 1, sizeof(cl_mem), &pair_word_b);
+    clSetKernelArg(k_read, 2, sizeof(cl_mem), &pair_count);
+    clSetKernelArg(k_read, 3, sizeof(cl_mem), &pair_mi);
+    clSetKernelArg(k_read, 4, sizeof(cl_mem), &pair_flags);
+    clSetKernelArg(k_read, 5, sizeof(cl_mem), &d_out_wa);
+    clSetKernelArg(k_read, 6, sizeof(cl_mem), &d_out_wb);
+    clSetKernelArg(k_read, 7, sizeof(cl_mem), &d_out_cnt);
+    clSetKernelArg(k_read, 8, sizeof(cl_mem), &d_out_mi);
+    clSetKernelArg(k_read, 9, sizeof(cl_mem), &d_out_flags);
+    clSetKernelArg(k_read, 10, sizeof(cl_uint), &np);
+
+    gs = ((h_num_pairs + local_size - 1) / local_size) * local_size;
+    err = clEnqueueNDRangeKernel(queue, k_read, 1, NULL,
+        &gs, &local_size, 0, NULL, NULL);
+    CL_CHECK(err, "enqueue read_pairs");
+    clFinish(queue);
+
+    uint32_t* r_wa = malloc(sizeof(uint32_t) * h_num_pairs);
+    uint32_t* r_wb = malloc(sizeof(uint32_t) * h_num_pairs);
+    double*   r_cnt = malloc(sizeof(double) * h_num_pairs);
+    uint32_t* r_flags = malloc(sizeof(uint32_t) * h_num_pairs);
+
+    clEnqueueReadBuffer(queue, d_out_wa, CL_TRUE, 0,
+        sizeof(uint32_t) * h_num_pairs, r_wa, 0, NULL, NULL);
+    clEnqueueReadBuffer(queue, d_out_wb, CL_TRUE, 0,
+        sizeof(uint32_t) * h_num_pairs, r_wb, 0, NULL, NULL);
+    clEnqueueReadBuffer(queue, d_out_cnt, CL_TRUE, 0,
+        sizeof(double) * h_num_pairs, r_cnt, 0, NULL, NULL);
+    clEnqueueReadBuffer(queue, d_out_flags, CL_TRUE, 0,
+        sizeof(uint32_t) * h_num_pairs, r_flags, 0, NULL, NULL);
+
+    int all_counted = 1;
+    int all_dirty = 1;
+    int all_canonical = 1;
+    double sum_counts = 0;
+
+    printf("  Pairs:\n");
+    for (uint32_t i = 0; i < h_num_pairs; i++) {
+        printf("    [%u] (%u, %u) count=%.0f flags=%u\n",
+               i, r_wa[i], r_wb[i], r_cnt[i], r_flags[i]);
+        if (r_cnt[i] < 0.5) all_counted = 0;
+        if (r_flags[i] != 1) all_dirty = 0;
+        if (r_wa[i] > r_wb[i]) all_canonical = 0;
+        sum_counts += r_cnt[i];
+    }
+
+    printf("  Sum of counts: %.0f (expected %u)\n", sum_counts, h_total);
+    printf("  All counts > 0: %s\n", all_counted ? "YES" : "NO");
+    printf("  All dirty flags: %s\n", all_dirty ? "YES" : "NO");
+    printf("  All canonical (a <= b): %s\n", all_canonical ? "YES" : "NO");
+
+    int t3_pass = all_counted && all_dirty && all_canonical &&
+                  (fabs(sum_counts - h_total) < 0.5);
+    printf("  %s\n\n", t3_pass ? "PASS" : "FAIL");
+    if (t3_pass) pass_count++; else fail_count++;
+
+    free(r_wa); free(r_wb); free(r_cnt); free(r_flags);
+    clReleaseMemObject(d_out_wa);
+    clReleaseMemObject(d_out_wb);
+    clReleaseMemObject(d_out_cnt);
+    clReleaseMemObject(d_out_mi);
+    clReleaseMemObject(d_out_flags);
+
+    /* ═══════════════════════════════════════════════════════════════
+     *  TEST 4: Binary search variant
+     *
+     *  Same input as Test 2, using count_sentence_pairs_large.
+     *  Should produce identical results.
+     * ═══════════════════════════════════════════════════════════════ */
+
+    printf("--- Test 4: Binary search variant ---\n");
+
+    reset_pools(queue, pht_keys, pht_values, pair_count, pair_mi,
+                pair_flags, word_count, pair_next_free, total_pair_count);
+
+    /* Set all 16 kernel args for count_sentence_pairs_large */
+    clSetKernelArg(k_count_large, 0, sizeof(cl_mem), &d_flat_words);
+    clSetKernelArg(k_count_large, 1, sizeof(cl_mem), &d_sent_offsets);
+    clSetKernelArg(k_count_large, 2, sizeof(cl_mem), &d_sent_lengths);
+    clSetKernelArg(k_count_large, 3, sizeof(cl_uint), &multi_ns);
+    clSetKernelArg(k_count_large, 4, sizeof(cl_uint), &multi_tw);
+    clSetKernelArg(k_count_large, 5, sizeof(cl_uint), &window_size);
+    clSetKernelArg(k_count_large, 6, sizeof(cl_mem), &pht_keys);
+    clSetKernelArg(k_count_large, 7, sizeof(cl_mem), &pht_values);
+    clSetKernelArg(k_count_large, 8, sizeof(cl_mem), &pair_word_a);
+    clSetKernelArg(k_count_large, 9, sizeof(cl_mem), &pair_word_b);
+    clSetKernelArg(k_count_large, 10, sizeof(cl_mem), &pair_count);
+    clSetKernelArg(k_count_large, 11, sizeof(cl_mem), &pair_mi);
+    clSetKernelArg(k_count_large, 12, sizeof(cl_mem), &pair_flags);
+    clSetKernelArg(k_count_large, 13, sizeof(cl_mem), &pair_next_free);
+    clSetKernelArg(k_count_large, 14, sizeof(cl_mem), &word_count);
+    clSetKernelArg(k_count_large, 15, sizeof(cl_mem), &total_pair_count);
+
+    t0 = now_ms();
+    gs = ((multi_tw + local_size - 1) / local_size) * local_size;
+    err = clEnqueueNDRangeKernel(queue, k_count_large, 1, NULL,
+        &gs, &local_size, 0, NULL, NULL);
+    CL_CHECK(err, "enqueue count_large");
+    clFinish(queue);
+    t1 = now_ms();
+
+    uint32_t h_pairs_large, h_total_large;
+    clEnqueueReadBuffer(queue, pair_next_free, CL_TRUE, 0,
+        sizeof(uint32_t), &h_pairs_large, 0, NULL, NULL);
+    clEnqueueReadBuffer(queue, total_pair_count, CL_TRUE, 0,
+        sizeof(uint32_t), &h_total_large, 0, NULL, NULL);
+
+    printf("  Pairs created: %u (expected 8)\n", h_pairs_large);
+    printf("  Total count events: %u (expected 8)\n", h_total_large);
+    printf("  Time: %.2f ms\n", t1 - t0);
+
+    /* Verify word marginals match Test 2's expected values */
+    double wc4[7];
+    clEnqueueReadBuffer(queue, word_count, CL_TRUE, 0,
+        sizeof(double) * 7, wc4, 0, NULL, NULL);
+    printf("  Word marginals: [0]=%.0f [1]=%.0f [2]=%.0f [3]=%.0f [4]=%.0f [5]=%.0f [6]=%.0f\n",
+           wc4[0], wc4[1], wc4[2], wc4[3], wc4[4], wc4[5], wc4[6]);
+    printf("    Expected:     [0]=2  [1]=3  [2]=3  [3]=2  [4]=2  [5]=2  [6]=2\n");
+
+    int t4_pass = (h_pairs_large == 8) && (h_total_large == 8) &&
+                  (fabs(wc4[0] - 2.0) < 0.5) && (fabs(wc4[1] - 3.0) < 0.5) &&
+                  (fabs(wc4[2] - 3.0) < 0.5) && (fabs(wc4[3] - 2.0) < 0.5) &&
+                  (fabs(wc4[4] - 2.0) < 0.5) && (fabs(wc4[5] - 2.0) < 0.5) &&
+                  (fabs(wc4[6] - 2.0) < 0.5);
+    printf("  %s\n\n", t4_pass ? "PASS" : "FAIL");
+    if (t4_pass) pass_count++; else fail_count++;
+
+    /* ═══════════════════════════════════════════════════════════════
+     *  TEST 5: Benchmark — 1000 sentences, window=6
+     *
+     *  500-word vocabulary, Zipf-like distribution, 5-20 words per
+     *  sentence. Compares linear scan vs binary search variant.
+     * ═══════════════════════════════════════════════════════════════ */
+
+    printf("--- Test 5: Benchmark (1000 sentences, window=6) ---\n");
+
+    reset_pools(queue, pht_keys, pht_values, pair_count, pair_mi,
+                pair_flags, word_count, pair_next_free, total_pair_count);
+
+    /* Generate 1000 sentences with Zipf-like word distribution */
+    int bench_ns = 1000;
+    uint32_t* bench_offsets = malloc(sizeof(uint32_t) * bench_ns);
+    uint32_t* bench_lengths = malloc(sizeof(uint32_t) * bench_ns);
+
+    uint64_t rng = 0xCAFEBABEDEADBEEFULL;
+    uint32_t bench_tw = 0;
+    for (int s = 0; s < bench_ns; s++) {
+        bench_offsets[s] = bench_tw;
+        rng += 0x9E3779B97F4A7C15ULL;
+        uint32_t slen = 5 + (uint32_t)((rng >> 32) % 16);
+        bench_lengths[s] = slen;
+        bench_tw += slen;
+    }
+
+    uint32_t* bench_words = malloc(sizeof(uint32_t) * bench_tw);
+    rng = 0xFEEDFACE12345678ULL;
+    for (uint32_t i = 0; i < bench_tw; i++) {
+        rng += 0x9E3779B97F4A7C15ULL;
+        double u = (double)(rng >> 32) / (double)0xFFFFFFFFU;
+        bench_words[i] = (uint32_t)(u * u * 499.0);
+    }
+
+    printf("  Sentences: %d, Total words: %u, Avg len: %.1f\n",
+           bench_ns, bench_tw, (float)bench_tw / bench_ns);
+
+    clReleaseMemObject(d_flat_words);
+    clReleaseMemObject(d_sent_offsets);
+    clReleaseMemObject(d_sent_lengths);
+
+    d_flat_words = clCreateBuffer(ctx, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint32_t) * bench_tw, bench_words, &err);
+    d_sent_offsets = clCreateBuffer(ctx, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint32_t) * bench_ns, bench_offsets, &err);
+    d_sent_lengths = clCreateBuffer(ctx, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint32_t) * bench_ns, bench_lengths, &err);
+
+    cl_uint bench_window = 6;
+    cl_uint bns = bench_ns;
+
+    /* Run linear scan variant */
+    clSetKernelArg(k_count, 0, sizeof(cl_mem), &d_flat_words);
+    clSetKernelArg(k_count, 1, sizeof(cl_mem), &d_sent_offsets);
+    clSetKernelArg(k_count, 2, sizeof(cl_mem), &d_sent_lengths);
+    clSetKernelArg(k_count, 3, sizeof(cl_uint), &bns);
+    clSetKernelArg(k_count, 4, sizeof(cl_uint), &bench_tw);
+    clSetKernelArg(k_count, 5, sizeof(cl_uint), &bench_window);
+
+    t0 = now_ms();
+    gs = ((bench_tw + local_size - 1) / local_size) * local_size;
+    err = clEnqueueNDRangeKernel(queue, k_count, 1, NULL,
+        &gs, &local_size, 0, NULL, NULL);
+    CL_CHECK(err, "enqueue bench count");
+    clFinish(queue);
+    t1 = now_ms();
+
+    uint32_t bench_pairs, bench_total;
+    clEnqueueReadBuffer(queue, pair_next_free, CL_TRUE, 0,
+        sizeof(uint32_t), &bench_pairs, 0, NULL, NULL);
+    clEnqueueReadBuffer(queue, total_pair_count, CL_TRUE, 0,
+        sizeof(uint32_t), &bench_total, 0, NULL, NULL);
+
+    double linear_ms = t1 - t0;
+    printf("  Linear scan: %.2f ms\n", linear_ms);
+    printf("  Unique pairs: %u\n", bench_pairs);
+    printf("  Total count events: %u\n", bench_total);
+    printf("  Throughput: %.0f K sentences/sec, %.0f K pair-events/sec\n",
+           bench_ns / (linear_ms / 1000.0) / 1000.0,
+           bench_total / (linear_ms / 1000.0) / 1000.0);
+
+    /* Run binary search variant with same data */
+    reset_pools(queue, pht_keys, pht_values, pair_count, pair_mi,
+                pair_flags, word_count, pair_next_free, total_pair_count);
+
+    clSetKernelArg(k_count_large, 0, sizeof(cl_mem), &d_flat_words);
+    clSetKernelArg(k_count_large, 1, sizeof(cl_mem), &d_sent_offsets);
+    clSetKernelArg(k_count_large, 2, sizeof(cl_mem), &d_sent_lengths);
+    clSetKernelArg(k_count_large, 3, sizeof(cl_uint), &bns);
+    clSetKernelArg(k_count_large, 4, sizeof(cl_uint), &bench_tw);
+    clSetKernelArg(k_count_large, 5, sizeof(cl_uint), &bench_window);
+    clSetKernelArg(k_count_large, 6, sizeof(cl_mem), &pht_keys);
+    clSetKernelArg(k_count_large, 7, sizeof(cl_mem), &pht_values);
+    clSetKernelArg(k_count_large, 8, sizeof(cl_mem), &pair_word_a);
+    clSetKernelArg(k_count_large, 9, sizeof(cl_mem), &pair_word_b);
+    clSetKernelArg(k_count_large, 10, sizeof(cl_mem), &pair_count);
+    clSetKernelArg(k_count_large, 11, sizeof(cl_mem), &pair_mi);
+    clSetKernelArg(k_count_large, 12, sizeof(cl_mem), &pair_flags);
+    clSetKernelArg(k_count_large, 13, sizeof(cl_mem), &pair_next_free);
+    clSetKernelArg(k_count_large, 14, sizeof(cl_mem), &word_count);
+    clSetKernelArg(k_count_large, 15, sizeof(cl_mem), &total_pair_count);
+
+    t0 = now_ms();
+    err = clEnqueueNDRangeKernel(queue, k_count_large, 1, NULL,
+        &gs, &local_size, 0, NULL, NULL);
+    CL_CHECK(err, "enqueue bench count_large");
+    clFinish(queue);
+    t1 = now_ms();
+
+    uint32_t bench_pairs_l, bench_total_l;
+    clEnqueueReadBuffer(queue, pair_next_free, CL_TRUE, 0,
+        sizeof(uint32_t), &bench_pairs_l, 0, NULL, NULL);
+    clEnqueueReadBuffer(queue, total_pair_count, CL_TRUE, 0,
+        sizeof(uint32_t), &bench_total_l, 0, NULL, NULL);
+
+    double binary_ms = t1 - t0;
+    printf("  Binary search: %.2f ms\n", binary_ms);
+    printf("  Unique pairs: %u (expected %u)\n", bench_pairs_l, bench_pairs);
+    printf("  Total count events: %u (expected %u)\n", bench_total_l, bench_total);
+    printf("  Throughput: %.0f K sentences/sec, %.0f K pair-events/sec\n",
+           bench_ns / (binary_ms / 1000.0) / 1000.0,
+           bench_total_l / (binary_ms / 1000.0) / 1000.0);
+
+    int t5_pass = (bench_pairs_l == bench_pairs) && (bench_total_l == bench_total);
+    printf("  Linear vs Binary match: %s\n", t5_pass ? "PASS" : "FAIL");
+    printf("  %s\n\n", t5_pass ? "PASS" : "FAIL");
+    if (t5_pass) pass_count++; else fail_count++;
+
+    /* ═══ Summary ═══ */
+
+    printf("=== Results: %d PASS, %d FAIL ===\n", pass_count, fail_count);
+
+    /* ─── Cleanup ─── */
+
+    clReleaseMemObject(pht_keys);
+    clReleaseMemObject(pht_values);
+    clReleaseMemObject(pair_word_a);
+    clReleaseMemObject(pair_word_b);
+    clReleaseMemObject(pair_count);
+    clReleaseMemObject(pair_mi);
+    clReleaseMemObject(pair_flags);
+    clReleaseMemObject(pair_next_free);
+    clReleaseMemObject(word_count);
+    clReleaseMemObject(total_pair_count);
+    clReleaseMemObject(d_flat_words);
+    clReleaseMemObject(d_sent_offsets);
+    clReleaseMemObject(d_sent_lengths);
+
+    clReleaseKernel(k_count);
+    clReleaseKernel(k_count_large);
+    clReleaseKernel(k_read);
+    clReleaseProgram(program);
+    clReleaseCommandQueue(queue);
+    clReleaseContext(ctx);
+
+    free(bench_offsets);
+    free(bench_lengths);
+    free(bench_words);
+    free(combined);
+    free(ht_src);
+    free(as_src);
+    free(ct_src);
+
+    return fail_count > 0 ? 1 : 0;
+}

--- a/opencog/opencl/atomspace/test-mi.c
+++ b/opencog/opencl/atomspace/test-mi.c
@@ -1,0 +1,961 @@
+/*
+ * test-mi.c -- Test GPU-resident MI computation
+ *
+ * Compile: gcc -O2 -o test-mi test-mi.c -lOpenCL -lm
+ * Run:     ./test-mi
+ *
+ * Tests the full pipeline: count sentences → compute MI → verify.
+ * All data stays on GPU — no CPU↔GPU marshaling for MI.
+ *
+ * Tests:
+ *   1. Manual MI verification (known counts → expected MI)
+ *   2. Pipeline: count → MI (sentences → pairs → MI in one flow)
+ *   3. Dirty-only MI (incremental recompute)
+ *   4. MI statistics (count positive/above-threshold)
+ *   5. MI filter (compact high-MI pairs)
+ *   6. Benchmark: 1000 sentences → MI on all pairs
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <math.h>
+#include <time.h>
+#include <CL/cl.h>
+
+/* ─── Pool capacities ─── */
+
+#define WORD_CAPACITY        (128 * 1024)
+#define PAIR_CAPACITY        (4 * 1024 * 1024)
+#define SECTION_CAPACITY     (1024 * 1024)
+#define WORD_HT_CAPACITY     (256 * 1024)
+#define PAIR_HT_CAPACITY     (8 * 1024 * 1024)
+#define SECTION_HT_CAPACITY  (2 * 1024 * 1024)
+
+#define HT_EMPTY_KEY    0xFFFFFFFFFFFFFFFFULL
+#define HT_EMPTY_VALUE  0xFFFFFFFFU
+
+/* ─── Error checking ─── */
+
+#define CL_CHECK(err, msg) do { \
+    if ((err) != CL_SUCCESS) { \
+        fprintf(stderr, "OpenCL error %d at %s:%d: %s\n", \
+                (err), __FILE__, __LINE__, (msg)); \
+        exit(1); \
+    } \
+} while(0)
+
+/* ─── Read file ─── */
+
+char* read_file(const char* path, size_t* len)
+{
+    FILE* f = fopen(path, "r");
+    if (!f) { fprintf(stderr, "Cannot open %s\n", path); exit(1); }
+    fseek(f, 0, SEEK_END);
+    *len = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    char* buf = malloc(*len + 1);
+    size_t n = fread(buf, 1, *len, f);
+    buf[n] = '\0';
+    *len = n;
+    fclose(f);
+    return buf;
+}
+
+/* ─── Timing ─── */
+
+double now_ms(void)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return ts.tv_sec * 1000.0 + ts.tv_nsec / 1000000.0;
+}
+
+/* ─── CPU MI for verification ─── */
+
+double cpu_mi(double count, double left_marg, double right_marg, double n)
+{
+    if (count < 1.0 || left_marg < 1e-10 || right_marg < 1e-10 || n < 1e-10)
+        return 0.0;
+    return log2(count * n / (left_marg * right_marg));
+}
+
+/* ─── Reset pools ─── */
+
+void reset_pools(cl_command_queue queue,
+                 cl_mem pht_keys, cl_mem pht_values,
+                 cl_mem pair_count, cl_mem pair_mi, cl_mem pair_flags,
+                 cl_mem word_count,
+                 cl_mem pair_next_free, cl_mem total_pair_count)
+{
+    uint8_t pat_ff = 0xFF, pat_00 = 0x00;
+    uint32_t zero = 0;
+
+    clEnqueueFillBuffer(queue, pht_keys, &pat_ff, 1, 0,
+        sizeof(uint64_t) * PAIR_HT_CAPACITY, 0, NULL, NULL);
+    clEnqueueFillBuffer(queue, pht_values, &pat_ff, 1, 0,
+        sizeof(uint32_t) * PAIR_HT_CAPACITY, 0, NULL, NULL);
+    clEnqueueFillBuffer(queue, pair_count, &pat_00, 1, 0,
+        sizeof(double) * PAIR_CAPACITY, 0, NULL, NULL);
+    clEnqueueFillBuffer(queue, pair_mi, &pat_00, 1, 0,
+        sizeof(double) * PAIR_CAPACITY, 0, NULL, NULL);
+    clEnqueueFillBuffer(queue, pair_flags, &pat_00, 1, 0,
+        sizeof(uint32_t) * PAIR_CAPACITY, 0, NULL, NULL);
+    clEnqueueFillBuffer(queue, word_count, &pat_00, 1, 0,
+        sizeof(double) * WORD_CAPACITY, 0, NULL, NULL);
+    clEnqueueWriteBuffer(queue, pair_next_free, CL_FALSE, 0,
+        sizeof(uint32_t), &zero, 0, NULL, NULL);
+    clEnqueueWriteBuffer(queue, total_pair_count, CL_FALSE, 0,
+        sizeof(uint32_t), &zero, 0, NULL, NULL);
+    clFinish(queue);
+}
+
+/* ─── Main ─── */
+
+int main(int argc, char** argv)
+{
+    cl_int err;
+    int pass_count = 0, fail_count = 0;
+
+    printf("=== GPU MI Computation Test ===\n\n");
+
+    /* ─── OpenCL setup ─── */
+
+    cl_platform_id platform;
+    err = clGetPlatformIDs(1, &platform, NULL);
+    CL_CHECK(err, "platform");
+
+    cl_device_id device;
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device, NULL);
+    CL_CHECK(err, "device");
+
+    char dev_name[256];
+    clGetDeviceInfo(device, CL_DEVICE_NAME, sizeof(dev_name), dev_name, NULL);
+    printf("GPU: %s\n", dev_name);
+
+    cl_context ctx = clCreateContext(NULL, 1, &device, NULL, NULL, &err);
+    CL_CHECK(err, "context");
+
+    cl_command_queue queue = clCreateCommandQueue(ctx, device, 0, &err);
+    CL_CHECK(err, "queue");
+
+    /* ─── Load and concatenate all 4 kernel sources ─── */
+
+    size_t ht_len, as_len, ct_len, mi_len;
+    char* ht_src = read_file("gpu-hashtable.cl", &ht_len);
+    char* as_src = read_file("gpu-atomspace.cl", &as_len);
+    char* ct_src = read_file("gpu-counting.cl", &ct_len);
+    char* mi_src = read_file("gpu-mi.cl", &mi_len);
+
+    size_t total_len = ht_len + 1 + as_len + 1 + ct_len + 1 + mi_len;
+    char* combined = malloc(total_len + 1);
+    size_t off = 0;
+    memcpy(combined + off, ht_src, ht_len); off += ht_len;
+    combined[off++] = '\n';
+    memcpy(combined + off, as_src, as_len); off += as_len;
+    combined[off++] = '\n';
+    memcpy(combined + off, ct_src, ct_len); off += ct_len;
+    combined[off++] = '\n';
+    memcpy(combined + off, mi_src, mi_len); off += mi_len;
+    combined[off] = '\0';
+
+    cl_program program = clCreateProgramWithSource(ctx, 1,
+        (const char**)&combined, &total_len, &err);
+    CL_CHECK(err, "create program");
+
+    char build_opts[512];
+    snprintf(build_opts, sizeof(build_opts),
+        "-cl-std=CL1.2 "
+        "-DWORD_CAPACITY=%d "
+        "-DPAIR_CAPACITY=%d "
+        "-DSECTION_CAPACITY=%d "
+        "-DWORD_HT_CAPACITY=%d "
+        "-DPAIR_HT_CAPACITY=%d "
+        "-DSECTION_HT_CAPACITY=%d",
+        WORD_CAPACITY, PAIR_CAPACITY, SECTION_CAPACITY,
+        WORD_HT_CAPACITY, PAIR_HT_CAPACITY, SECTION_HT_CAPACITY);
+
+    err = clBuildProgram(program, 1, &device, build_opts, NULL, NULL);
+    if (err != CL_SUCCESS) {
+        char log[16384];
+        clGetProgramBuildInfo(program, device, CL_PROGRAM_BUILD_LOG,
+                              sizeof(log), log, NULL);
+        fprintf(stderr, "Build error:\n%s\n", log);
+        return 1;
+    }
+    printf("All kernels compiled successfully\n\n");
+
+    /* ─── Create kernels ─── */
+
+    cl_kernel k_count = clCreateKernel(program, "count_sentence_pairs", &err);
+    CL_CHECK(err, "kernel count_sentence_pairs");
+    cl_kernel k_mi_all = clCreateKernel(program, "compute_mi_resident", &err);
+    CL_CHECK(err, "kernel compute_mi_resident");
+    cl_kernel k_mi_dirty = clCreateKernel(program, "compute_mi_dirty", &err);
+    CL_CHECK(err, "kernel compute_mi_dirty");
+    cl_kernel k_mi_stats = clCreateKernel(program, "mi_stats", &err);
+    CL_CHECK(err, "kernel mi_stats");
+    cl_kernel k_mi_filter = clCreateKernel(program, "mi_filter", &err);
+    CL_CHECK(err, "kernel mi_filter");
+    cl_kernel k_read_mi = clCreateKernel(program, "read_pairs_with_mi", &err);
+    CL_CHECK(err, "kernel read_pairs_with_mi");
+
+    size_t local_size = 256;
+
+    /* ─── Allocate GPU buffers ─── */
+
+    uint32_t zero = 0;
+
+    cl_mem pht_keys = clCreateBuffer(ctx, CL_MEM_READ_WRITE,
+        sizeof(uint64_t) * PAIR_HT_CAPACITY, NULL, &err);
+    cl_mem pht_values = clCreateBuffer(ctx, CL_MEM_READ_WRITE,
+        sizeof(uint32_t) * PAIR_HT_CAPACITY, NULL, &err);
+    cl_mem pair_word_a = clCreateBuffer(ctx, CL_MEM_READ_WRITE,
+        sizeof(uint32_t) * PAIR_CAPACITY, NULL, &err);
+    cl_mem pair_word_b = clCreateBuffer(ctx, CL_MEM_READ_WRITE,
+        sizeof(uint32_t) * PAIR_CAPACITY, NULL, &err);
+    cl_mem pair_count = clCreateBuffer(ctx, CL_MEM_READ_WRITE,
+        sizeof(double) * PAIR_CAPACITY, NULL, &err);
+    cl_mem pair_mi = clCreateBuffer(ctx, CL_MEM_READ_WRITE,
+        sizeof(double) * PAIR_CAPACITY, NULL, &err);
+    cl_mem pair_flags = clCreateBuffer(ctx, CL_MEM_READ_WRITE,
+        sizeof(uint32_t) * PAIR_CAPACITY, NULL, &err);
+    cl_mem pair_next_free = clCreateBuffer(ctx, CL_MEM_READ_WRITE | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint32_t), &zero, &err);
+    cl_mem word_count = clCreateBuffer(ctx, CL_MEM_READ_WRITE,
+        sizeof(double) * WORD_CAPACITY, NULL, &err);
+    cl_mem total_pair_count = clCreateBuffer(ctx, CL_MEM_READ_WRITE | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint32_t), &zero, &err);
+
+    reset_pools(queue, pht_keys, pht_values, pair_count, pair_mi,
+                pair_flags, word_count, pair_next_free, total_pair_count);
+
+    printf("GPU buffers ready\n\n");
+
+    /* ═══════════════════════════════════════════════════════════════
+     *  TEST 1: Manual MI verification
+     *
+     *  Manually set pair counts and word marginals, then verify
+     *  that compute_mi_resident produces correct MI values.
+     *
+     *  Setup (3 pairs, 4 words):
+     *    pair 0: (word0, word1) count=10  → MI = log2(10*100/(30*40))
+     *    pair 1: (word0, word2) count=5   → MI = log2(5*100/(30*20))
+     *    pair 2: (word1, word3) count=20  → MI = log2(20*100/(40*50))
+     *
+     *  Word marginals: word0=30, word1=40, word2=20, word3=50
+     *  N = 100 (total pair observations)
+     * ═══════════════════════════════════════════════════════════════ */
+
+    printf("--- Test 1: Manual MI verification ---\n");
+
+    /* Write pair data directly to GPU */
+    uint32_t h_pa[] = {0, 0, 1};
+    uint32_t h_pb[] = {1, 2, 3};
+    double   h_pc[] = {10.0, 5.0, 20.0};
+    double   h_wc[] = {30.0, 40.0, 20.0, 50.0};
+    uint32_t h_np = 3;
+
+    clEnqueueWriteBuffer(queue, pair_word_a, CL_FALSE, 0,
+        sizeof(uint32_t) * 3, h_pa, 0, NULL, NULL);
+    clEnqueueWriteBuffer(queue, pair_word_b, CL_FALSE, 0,
+        sizeof(uint32_t) * 3, h_pb, 0, NULL, NULL);
+    clEnqueueWriteBuffer(queue, pair_count, CL_FALSE, 0,
+        sizeof(double) * 3, h_pc, 0, NULL, NULL);
+    clEnqueueWriteBuffer(queue, word_count, CL_FALSE, 0,
+        sizeof(double) * 4, h_wc, 0, NULL, NULL);
+    clEnqueueWriteBuffer(queue, pair_next_free, CL_FALSE, 0,
+        sizeof(uint32_t), &h_np, 0, NULL, NULL);
+    clFinish(queue);
+
+    /* Compute expected MI on CPU */
+    double n_total = 100.0;
+    double expected_mi[3];
+    expected_mi[0] = cpu_mi(10.0, 30.0, 40.0, 100.0);  /* log2(10*100/1200) */
+    expected_mi[1] = cpu_mi(5.0,  30.0, 20.0, 100.0);   /* log2(5*100/600) */
+    expected_mi[2] = cpu_mi(20.0, 40.0, 50.0, 100.0);  /* log2(20*100/2000) */
+
+    printf("  Expected MI: [%.4f, %.4f, %.4f]\n",
+           expected_mi[0], expected_mi[1], expected_mi[2]);
+
+    /* Run MI kernel */
+    cl_uint np = 3;
+    clSetKernelArg(k_mi_all, 0, sizeof(cl_mem), &pair_count);
+    clSetKernelArg(k_mi_all, 1, sizeof(cl_mem), &pair_word_a);
+    clSetKernelArg(k_mi_all, 2, sizeof(cl_mem), &pair_word_b);
+    clSetKernelArg(k_mi_all, 3, sizeof(cl_mem), &pair_mi);
+    clSetKernelArg(k_mi_all, 4, sizeof(cl_mem), &word_count);
+    clSetKernelArg(k_mi_all, 5, sizeof(cl_double), &n_total);
+    clSetKernelArg(k_mi_all, 6, sizeof(cl_uint), &np);
+
+    size_t gs = ((np + local_size - 1) / local_size) * local_size;
+    double t0 = now_ms();
+    err = clEnqueueNDRangeKernel(queue, k_mi_all, 1, NULL,
+        &gs, &local_size, 0, NULL, NULL);
+    CL_CHECK(err, "enqueue mi_all");
+    clFinish(queue);
+    double t1 = now_ms();
+
+    /* Read back MI values */
+    double gpu_mi[3];
+    clEnqueueReadBuffer(queue, pair_mi, CL_TRUE, 0,
+        sizeof(double) * 3, gpu_mi, 0, NULL, NULL);
+
+    printf("  GPU MI:      [%.4f, %.4f, %.4f]\n",
+           gpu_mi[0], gpu_mi[1], gpu_mi[2]);
+    printf("  Time: %.2f ms\n", t1 - t0);
+
+    int t1_pass = 1;
+    for (int i = 0; i < 3; i++) {
+        double diff = fabs(gpu_mi[i] - expected_mi[i]);
+        if (diff > 0.001) {
+            printf("  MISMATCH pair %d: gpu=%.6f expected=%.6f diff=%.6f\n",
+                   i, gpu_mi[i], expected_mi[i], diff);
+            t1_pass = 0;
+        }
+    }
+    printf("  %s\n\n", t1_pass ? "PASS" : "FAIL");
+    if (t1_pass) pass_count++; else fail_count++;
+
+    /* ═══════════════════════════════════════════════════════════════
+     *  TEST 2: Full pipeline — count sentences → compute MI
+     *
+     *  Run count_sentence_pairs on test sentences, then immediately
+     *  run compute_mi_resident on the same GPU-resident data.
+     *  All data stays on GPU — zero transfers between stages.
+     *
+     *  Sentence 1: [0, 1, 2, 3]  (4 words, window=2)
+     *  Sentence 2: [4, 5, 6]     (3 words)
+     *
+     *  Expected: 8 pairs from counting, all get valid MI > 0.
+     * ═══════════════════════════════════════════════════════════════ */
+
+    printf("--- Test 2: Full pipeline (count → MI) ---\n");
+
+    reset_pools(queue, pht_keys, pht_values, pair_count, pair_mi,
+                pair_flags, word_count, pair_next_free, total_pair_count);
+
+    uint32_t sent_words[] = {0, 1, 2, 3, 4, 5, 6};
+    uint32_t sent_offsets[] = {0, 4};
+    uint32_t sent_lengths[] = {4, 3};
+    cl_uint num_sentences = 2;
+    cl_uint tw = 7;
+    cl_uint window_size = 2;
+
+    cl_mem d_flat_words = clCreateBuffer(ctx, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint32_t) * tw, sent_words, &err);
+    cl_mem d_sent_offsets = clCreateBuffer(ctx, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint32_t) * num_sentences, sent_offsets, &err);
+    cl_mem d_sent_lengths = clCreateBuffer(ctx, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint32_t) * num_sentences, sent_lengths, &err);
+
+    /* Stage 1: Count pairs */
+    clSetKernelArg(k_count, 0, sizeof(cl_mem), &d_flat_words);
+    clSetKernelArg(k_count, 1, sizeof(cl_mem), &d_sent_offsets);
+    clSetKernelArg(k_count, 2, sizeof(cl_mem), &d_sent_lengths);
+    clSetKernelArg(k_count, 3, sizeof(cl_uint), &num_sentences);
+    clSetKernelArg(k_count, 4, sizeof(cl_uint), &tw);
+    clSetKernelArg(k_count, 5, sizeof(cl_uint), &window_size);
+    clSetKernelArg(k_count, 6, sizeof(cl_mem), &pht_keys);
+    clSetKernelArg(k_count, 7, sizeof(cl_mem), &pht_values);
+    clSetKernelArg(k_count, 8, sizeof(cl_mem), &pair_word_a);
+    clSetKernelArg(k_count, 9, sizeof(cl_mem), &pair_word_b);
+    clSetKernelArg(k_count, 10, sizeof(cl_mem), &pair_count);
+    clSetKernelArg(k_count, 11, sizeof(cl_mem), &pair_mi);
+    clSetKernelArg(k_count, 12, sizeof(cl_mem), &pair_flags);
+    clSetKernelArg(k_count, 13, sizeof(cl_mem), &pair_next_free);
+    clSetKernelArg(k_count, 14, sizeof(cl_mem), &word_count);
+    clSetKernelArg(k_count, 15, sizeof(cl_mem), &total_pair_count);
+
+    t0 = now_ms();
+    gs = ((tw + local_size - 1) / local_size) * local_size;
+    err = clEnqueueNDRangeKernel(queue, k_count, 1, NULL,
+        &gs, &local_size, 0, NULL, NULL);
+    CL_CHECK(err, "enqueue count");
+    clFinish(queue);
+    double t_count = now_ms() - t0;
+
+    /* Read num_pairs and total for MI computation */
+    uint32_t h_num_pairs, h_total;
+    clEnqueueReadBuffer(queue, pair_next_free, CL_TRUE, 0,
+        sizeof(uint32_t), &h_num_pairs, 0, NULL, NULL);
+    clEnqueueReadBuffer(queue, total_pair_count, CL_TRUE, 0,
+        sizeof(uint32_t), &h_total, 0, NULL, NULL);
+
+    printf("  Stage 1 (count): %u pairs, %u events in %.2f ms\n",
+           h_num_pairs, h_total, t_count);
+
+    /* Stage 2: Compute MI — data stays on GPU! */
+    double n = (double)h_total;
+    clSetKernelArg(k_mi_all, 0, sizeof(cl_mem), &pair_count);
+    clSetKernelArg(k_mi_all, 1, sizeof(cl_mem), &pair_word_a);
+    clSetKernelArg(k_mi_all, 2, sizeof(cl_mem), &pair_word_b);
+    clSetKernelArg(k_mi_all, 3, sizeof(cl_mem), &pair_mi);
+    clSetKernelArg(k_mi_all, 4, sizeof(cl_mem), &word_count);
+    clSetKernelArg(k_mi_all, 5, sizeof(cl_double), &n);
+    clSetKernelArg(k_mi_all, 6, sizeof(cl_uint), &h_num_pairs);
+
+    t0 = now_ms();
+    gs = ((h_num_pairs + local_size - 1) / local_size) * local_size;
+    err = clEnqueueNDRangeKernel(queue, k_mi_all, 1, NULL,
+        &gs, &local_size, 0, NULL, NULL);
+    CL_CHECK(err, "enqueue mi_all pipeline");
+    clFinish(queue);
+    double t_mi = now_ms() - t0;
+
+    printf("  Stage 2 (MI):    %u pairs in %.2f ms\n", h_num_pairs, t_mi);
+    printf("  Total pipeline:  %.2f ms (zero transfers between stages)\n",
+           t_count + t_mi);
+
+    /* Read back and verify with read_pairs_with_mi */
+    cl_mem d_out_wa = clCreateBuffer(ctx, CL_MEM_WRITE_ONLY,
+        sizeof(uint32_t) * h_num_pairs, NULL, &err);
+    cl_mem d_out_wb = clCreateBuffer(ctx, CL_MEM_WRITE_ONLY,
+        sizeof(uint32_t) * h_num_pairs, NULL, &err);
+    cl_mem d_out_cnt = clCreateBuffer(ctx, CL_MEM_WRITE_ONLY,
+        sizeof(double) * h_num_pairs, NULL, &err);
+    cl_mem d_out_mi = clCreateBuffer(ctx, CL_MEM_WRITE_ONLY,
+        sizeof(double) * h_num_pairs, NULL, &err);
+    cl_mem d_out_lm = clCreateBuffer(ctx, CL_MEM_WRITE_ONLY,
+        sizeof(double) * h_num_pairs, NULL, &err);
+    cl_mem d_out_rm = clCreateBuffer(ctx, CL_MEM_WRITE_ONLY,
+        sizeof(double) * h_num_pairs, NULL, &err);
+
+    clSetKernelArg(k_read_mi, 0, sizeof(cl_mem), &pair_word_a);
+    clSetKernelArg(k_read_mi, 1, sizeof(cl_mem), &pair_word_b);
+    clSetKernelArg(k_read_mi, 2, sizeof(cl_mem), &pair_count);
+    clSetKernelArg(k_read_mi, 3, sizeof(cl_mem), &pair_mi);
+    clSetKernelArg(k_read_mi, 4, sizeof(cl_mem), &pair_flags);
+    clSetKernelArg(k_read_mi, 5, sizeof(cl_mem), &word_count);
+    clSetKernelArg(k_read_mi, 6, sizeof(cl_mem), &d_out_wa);
+    clSetKernelArg(k_read_mi, 7, sizeof(cl_mem), &d_out_wb);
+    clSetKernelArg(k_read_mi, 8, sizeof(cl_mem), &d_out_cnt);
+    clSetKernelArg(k_read_mi, 9, sizeof(cl_mem), &d_out_mi);
+    clSetKernelArg(k_read_mi, 10, sizeof(cl_mem), &d_out_lm);
+    clSetKernelArg(k_read_mi, 11, sizeof(cl_mem), &d_out_rm);
+    clSetKernelArg(k_read_mi, 12, sizeof(cl_uint), &h_num_pairs);
+
+    gs = ((h_num_pairs + local_size - 1) / local_size) * local_size;
+    clEnqueueNDRangeKernel(queue, k_read_mi, 1, NULL,
+        &gs, &local_size, 0, NULL, NULL);
+    clFinish(queue);
+
+    uint32_t* r_wa = malloc(sizeof(uint32_t) * h_num_pairs);
+    uint32_t* r_wb = malloc(sizeof(uint32_t) * h_num_pairs);
+    double*   r_cnt = malloc(sizeof(double) * h_num_pairs);
+    double*   r_mi = malloc(sizeof(double) * h_num_pairs);
+    double*   r_lm = malloc(sizeof(double) * h_num_pairs);
+    double*   r_rm = malloc(sizeof(double) * h_num_pairs);
+
+    clEnqueueReadBuffer(queue, d_out_wa, CL_TRUE, 0, sizeof(uint32_t)*h_num_pairs, r_wa, 0, NULL, NULL);
+    clEnqueueReadBuffer(queue, d_out_wb, CL_TRUE, 0, sizeof(uint32_t)*h_num_pairs, r_wb, 0, NULL, NULL);
+    clEnqueueReadBuffer(queue, d_out_cnt, CL_TRUE, 0, sizeof(double)*h_num_pairs, r_cnt, 0, NULL, NULL);
+    clEnqueueReadBuffer(queue, d_out_mi, CL_TRUE, 0, sizeof(double)*h_num_pairs, r_mi, 0, NULL, NULL);
+    clEnqueueReadBuffer(queue, d_out_lm, CL_TRUE, 0, sizeof(double)*h_num_pairs, r_lm, 0, NULL, NULL);
+    clEnqueueReadBuffer(queue, d_out_rm, CL_TRUE, 0, sizeof(double)*h_num_pairs, r_rm, 0, NULL, NULL);
+
+    int t2_pass = 1;
+    int all_mi_valid = 1;
+    printf("  Pair details:\n");
+    for (uint32_t i = 0; i < h_num_pairs; i++) {
+        double exp = cpu_mi(r_cnt[i], r_lm[i], r_rm[i], n);
+        double diff = fabs(r_mi[i] - exp);
+        printf("    [%u] (%u,%u) cnt=%.0f lm=%.0f rm=%.0f MI=%.4f (exp=%.4f) %s\n",
+               i, r_wa[i], r_wb[i], r_cnt[i], r_lm[i], r_rm[i],
+               r_mi[i], exp, (diff < 0.001) ? "OK" : "MISMATCH");
+        if (diff > 0.001) { t2_pass = 0; all_mi_valid = 0; }
+    }
+    printf("  All MI values match CPU: %s\n", all_mi_valid ? "YES" : "NO");
+    t2_pass = t2_pass && (h_num_pairs == 8);
+    printf("  %s\n\n", t2_pass ? "PASS" : "FAIL");
+    if (t2_pass) pass_count++; else fail_count++;
+
+    free(r_wa); free(r_wb); free(r_cnt); free(r_mi); free(r_lm); free(r_rm);
+    clReleaseMemObject(d_out_wa); clReleaseMemObject(d_out_wb);
+    clReleaseMemObject(d_out_cnt); clReleaseMemObject(d_out_mi);
+    clReleaseMemObject(d_out_lm); clReleaseMemObject(d_out_rm);
+
+    /* ═══════════════════════════════════════════════════════════════
+     *  TEST 3: Dirty-only MI recompute
+     *
+     *  After counting, all pairs have flags=1 (dirty).
+     *  Run compute_mi_dirty — should compute MI and clear flags.
+     *  Then add more sentences, creating new dirty pairs.
+     *  Run compute_mi_dirty again — should only recompute dirty ones.
+     * ═══════════════════════════════════════════════════════════════ */
+
+    printf("--- Test 3: Dirty-only MI recompute ---\n");
+
+    reset_pools(queue, pht_keys, pht_values, pair_count, pair_mi,
+                pair_flags, word_count, pair_next_free, total_pair_count);
+
+    /* Count first batch: [0, 1, 2] window=2 → pairs (0,1),(0,2),(1,2) */
+    uint32_t batch1_words[] = {0, 1, 2};
+    uint32_t batch1_offset = 0;
+    uint32_t batch1_length = 3;
+    cl_uint b1_ns = 1, b1_tw = 3, b1_ws = 2;
+
+    clReleaseMemObject(d_flat_words);
+    clReleaseMemObject(d_sent_offsets);
+    clReleaseMemObject(d_sent_lengths);
+
+    d_flat_words = clCreateBuffer(ctx, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint32_t) * 3, batch1_words, &err);
+    d_sent_offsets = clCreateBuffer(ctx, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint32_t), &batch1_offset, &err);
+    d_sent_lengths = clCreateBuffer(ctx, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint32_t), &batch1_length, &err);
+
+    clSetKernelArg(k_count, 0, sizeof(cl_mem), &d_flat_words);
+    clSetKernelArg(k_count, 1, sizeof(cl_mem), &d_sent_offsets);
+    clSetKernelArg(k_count, 2, sizeof(cl_mem), &d_sent_lengths);
+    clSetKernelArg(k_count, 3, sizeof(cl_uint), &b1_ns);
+    clSetKernelArg(k_count, 4, sizeof(cl_uint), &b1_tw);
+    clSetKernelArg(k_count, 5, sizeof(cl_uint), &b1_ws);
+
+    clEnqueueNDRangeKernel(queue, k_count, 1, NULL,
+        &local_size, &local_size, 0, NULL, NULL);
+    clFinish(queue);
+
+    clEnqueueReadBuffer(queue, pair_next_free, CL_TRUE, 0,
+        sizeof(uint32_t), &h_num_pairs, 0, NULL, NULL);
+    clEnqueueReadBuffer(queue, total_pair_count, CL_TRUE, 0,
+        sizeof(uint32_t), &h_total, 0, NULL, NULL);
+
+    printf("  Batch 1: %u pairs, %u events\n", h_num_pairs, h_total);
+
+    /* Run dirty MI — should process all 3 pairs and clear flags */
+    n = (double)h_total;
+    clSetKernelArg(k_mi_dirty, 0, sizeof(cl_mem), &pair_count);
+    clSetKernelArg(k_mi_dirty, 1, sizeof(cl_mem), &pair_word_a);
+    clSetKernelArg(k_mi_dirty, 2, sizeof(cl_mem), &pair_word_b);
+    clSetKernelArg(k_mi_dirty, 3, sizeof(cl_mem), &pair_mi);
+    clSetKernelArg(k_mi_dirty, 4, sizeof(cl_mem), &pair_flags);
+    clSetKernelArg(k_mi_dirty, 5, sizeof(cl_mem), &word_count);
+    clSetKernelArg(k_mi_dirty, 6, sizeof(cl_double), &n);
+    clSetKernelArg(k_mi_dirty, 7, sizeof(cl_uint), &h_num_pairs);
+
+    gs = ((h_num_pairs + local_size - 1) / local_size) * local_size;
+    clEnqueueNDRangeKernel(queue, k_mi_dirty, 1, NULL,
+        &gs, &local_size, 0, NULL, NULL);
+    clFinish(queue);
+
+    /* Verify flags are cleared */
+    uint32_t flags_after[3];
+    clEnqueueReadBuffer(queue, pair_flags, CL_TRUE, 0,
+        sizeof(uint32_t) * 3, flags_after, 0, NULL, NULL);
+
+    int all_clear = (flags_after[0] == 0 && flags_after[1] == 0 && flags_after[2] == 0);
+    printf("  After dirty MI: flags=[%u,%u,%u] (all 0?) %s\n",
+           flags_after[0], flags_after[1], flags_after[2],
+           all_clear ? "YES" : "NO");
+
+    /* Read MI values after first batch */
+    double mi_batch1[3];
+    clEnqueueReadBuffer(queue, pair_mi, CL_TRUE, 0,
+        sizeof(double) * 3, mi_batch1, 0, NULL, NULL);
+    printf("  MI after batch 1: [%.4f, %.4f, %.4f]\n",
+           mi_batch1[0], mi_batch1[1], mi_batch1[2]);
+
+    /* Count second batch: [1, 2, 3] window=2 → new pair (1,3),(2,3) + existing (1,2) */
+    uint32_t batch2_words[] = {1, 2, 3};
+    uint32_t batch2_offset = 0;
+    uint32_t batch2_length = 3;
+
+    clReleaseMemObject(d_flat_words);
+    d_flat_words = clCreateBuffer(ctx, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint32_t) * 3, batch2_words, &err);
+
+    clSetKernelArg(k_count, 0, sizeof(cl_mem), &d_flat_words);
+    clSetKernelArg(k_count, 4, sizeof(cl_uint), &b1_tw);
+
+    clEnqueueNDRangeKernel(queue, k_count, 1, NULL,
+        &local_size, &local_size, 0, NULL, NULL);
+    clFinish(queue);
+
+    uint32_t h_num_pairs2, h_total2;
+    clEnqueueReadBuffer(queue, pair_next_free, CL_TRUE, 0,
+        sizeof(uint32_t), &h_num_pairs2, 0, NULL, NULL);
+    clEnqueueReadBuffer(queue, total_pair_count, CL_TRUE, 0,
+        sizeof(uint32_t), &h_total2, 0, NULL, NULL);
+
+    printf("  Batch 2: %u total pairs, %u total events\n", h_num_pairs2, h_total2);
+
+    /* Run dirty MI again — should only recompute dirty pairs */
+    n = (double)h_total2;
+    clSetKernelArg(k_mi_dirty, 6, sizeof(cl_double), &n);
+    clSetKernelArg(k_mi_dirty, 7, sizeof(cl_uint), &h_num_pairs2);
+
+    gs = ((h_num_pairs2 + local_size - 1) / local_size) * local_size;
+    clEnqueueNDRangeKernel(queue, k_mi_dirty, 1, NULL,
+        &gs, &local_size, 0, NULL, NULL);
+    clFinish(queue);
+
+    /* Read all MI values */
+    double mi_batch2[5];
+    uint32_t flags_after2[5];
+    clEnqueueReadBuffer(queue, pair_mi, CL_TRUE, 0,
+        sizeof(double) * h_num_pairs2, mi_batch2, 0, NULL, NULL);
+    clEnqueueReadBuffer(queue, pair_flags, CL_TRUE, 0,
+        sizeof(uint32_t) * h_num_pairs2, flags_after2, 0, NULL, NULL);
+
+    printf("  MI after batch 2:\n");
+    int t3_pass = all_clear;
+    for (uint32_t i = 0; i < h_num_pairs2; i++) {
+        printf("    pair[%u] MI=%.4f flags=%u\n", i, mi_batch2[i], flags_after2[i]);
+        if (flags_after2[i] != 0) t3_pass = 0;
+        /* MI should be non-zero for all counted pairs */
+        if (fabs(mi_batch2[i]) < 0.001) t3_pass = 0;
+    }
+    printf("  All flags cleared: %s\n",
+           (t3_pass) ? "YES" : "NO");
+    printf("  %s\n\n", t3_pass ? "PASS" : "FAIL");
+    if (t3_pass) pass_count++; else fail_count++;
+
+    /* ═══════════════════════════════════════════════════════════════
+     *  TEST 4: MI statistics
+     * ═══════════════════════════════════════════════════════════════ */
+
+    printf("--- Test 4: MI statistics ---\n");
+
+    /* Use the data from Test 3 (5 pairs, all with MI > 0) */
+    cl_mem d_cnt_nz = clCreateBuffer(ctx, CL_MEM_READ_WRITE | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint32_t), &zero, &err);
+    cl_mem d_cnt_pos = clCreateBuffer(ctx, CL_MEM_READ_WRITE | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint32_t), &zero, &err);
+    cl_mem d_cnt_at = clCreateBuffer(ctx, CL_MEM_READ_WRITE | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint32_t), &zero, &err);
+
+    cl_double threshold = 1.0;
+
+    clSetKernelArg(k_mi_stats, 0, sizeof(cl_mem), &pair_mi);
+    clSetKernelArg(k_mi_stats, 1, sizeof(cl_mem), &pair_count);
+    clSetKernelArg(k_mi_stats, 2, sizeof(cl_uint), &h_num_pairs2);
+    clSetKernelArg(k_mi_stats, 3, sizeof(cl_double), &threshold);
+    clSetKernelArg(k_mi_stats, 4, sizeof(cl_mem), &d_cnt_nz);
+    clSetKernelArg(k_mi_stats, 5, sizeof(cl_mem), &d_cnt_pos);
+    clSetKernelArg(k_mi_stats, 6, sizeof(cl_mem), &d_cnt_at);
+
+    gs = ((h_num_pairs2 + local_size - 1) / local_size) * local_size;
+    clEnqueueNDRangeKernel(queue, k_mi_stats, 1, NULL,
+        &gs, &local_size, 0, NULL, NULL);
+    clFinish(queue);
+
+    uint32_t cnt_nz, cnt_pos, cnt_at;
+    clEnqueueReadBuffer(queue, d_cnt_nz, CL_TRUE, 0, sizeof(uint32_t), &cnt_nz, 0, NULL, NULL);
+    clEnqueueReadBuffer(queue, d_cnt_pos, CL_TRUE, 0, sizeof(uint32_t), &cnt_pos, 0, NULL, NULL);
+    clEnqueueReadBuffer(queue, d_cnt_at, CL_TRUE, 0, sizeof(uint32_t), &cnt_at, 0, NULL, NULL);
+
+    printf("  Pairs with count > 0: %u (expected %u)\n", cnt_nz, h_num_pairs2);
+    printf("  Pairs with MI > 0:    %u\n", cnt_pos);
+    printf("  Pairs with MI > %.1f: %u\n", threshold, cnt_at);
+
+    /* Count expected on CPU */
+    int exp_pos = 0, exp_at = 0;
+    for (uint32_t i = 0; i < h_num_pairs2; i++) {
+        if (mi_batch2[i] > 0.0) exp_pos++;
+        if (mi_batch2[i] > threshold) exp_at++;
+    }
+
+    int t4_pass = (cnt_nz == h_num_pairs2) && (cnt_pos == (uint32_t)exp_pos)
+                  && (cnt_at == (uint32_t)exp_at);
+    printf("  Expected: pos=%d above=%.1f=%d\n", exp_pos, threshold, exp_at);
+    printf("  %s\n\n", t4_pass ? "PASS" : "FAIL");
+    if (t4_pass) pass_count++; else fail_count++;
+
+    clReleaseMemObject(d_cnt_nz);
+    clReleaseMemObject(d_cnt_pos);
+    clReleaseMemObject(d_cnt_at);
+
+    /* ═══════════════════════════════════════════════════════════════
+     *  TEST 5: MI filter (compact high-MI pairs)
+     * ═══════════════════════════════════════════════════════════════ */
+
+    printf("--- Test 5: MI filter ---\n");
+
+    uint32_t max_output = 100;
+    cl_mem d_filt_idx = clCreateBuffer(ctx, CL_MEM_WRITE_ONLY,
+        sizeof(uint32_t) * max_output, NULL, &err);
+    cl_mem d_filt_mi = clCreateBuffer(ctx, CL_MEM_WRITE_ONLY,
+        sizeof(double) * max_output, NULL, &err);
+    cl_mem d_filt_cnt = clCreateBuffer(ctx, CL_MEM_READ_WRITE | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint32_t), &zero, &err);
+
+    cl_double mi_thresh = 1.0;
+
+    clSetKernelArg(k_mi_filter, 0, sizeof(cl_mem), &pair_mi);
+    clSetKernelArg(k_mi_filter, 1, sizeof(cl_mem), &pair_count);
+    clSetKernelArg(k_mi_filter, 2, sizeof(cl_uint), &h_num_pairs2);
+    clSetKernelArg(k_mi_filter, 3, sizeof(cl_double), &mi_thresh);
+    clSetKernelArg(k_mi_filter, 4, sizeof(cl_mem), &d_filt_idx);
+    clSetKernelArg(k_mi_filter, 5, sizeof(cl_mem), &d_filt_mi);
+    clSetKernelArg(k_mi_filter, 6, sizeof(cl_mem), &d_filt_cnt);
+    clSetKernelArg(k_mi_filter, 7, sizeof(cl_uint), &max_output);
+
+    gs = ((h_num_pairs2 + local_size - 1) / local_size) * local_size;
+    clEnqueueNDRangeKernel(queue, k_mi_filter, 1, NULL,
+        &gs, &local_size, 0, NULL, NULL);
+    clFinish(queue);
+
+    uint32_t filt_count;
+    clEnqueueReadBuffer(queue, d_filt_cnt, CL_TRUE, 0,
+        sizeof(uint32_t), &filt_count, 0, NULL, NULL);
+
+    printf("  Pairs with MI > %.1f: %u (expected %u)\n",
+           mi_thresh, filt_count, cnt_at);
+
+    if (filt_count > 0 && filt_count <= max_output) {
+        uint32_t* f_idx = malloc(sizeof(uint32_t) * filt_count);
+        double*   f_mi  = malloc(sizeof(double) * filt_count);
+        clEnqueueReadBuffer(queue, d_filt_idx, CL_TRUE, 0,
+            sizeof(uint32_t) * filt_count, f_idx, 0, NULL, NULL);
+        clEnqueueReadBuffer(queue, d_filt_mi, CL_TRUE, 0,
+            sizeof(double) * filt_count, f_mi, 0, NULL, NULL);
+
+        printf("  Filtered pairs:\n");
+        for (uint32_t i = 0; i < filt_count; i++) {
+            printf("    pair[%u] MI=%.4f\n", f_idx[i], f_mi[i]);
+        }
+        free(f_idx); free(f_mi);
+    }
+
+    int t5_pass = (filt_count == cnt_at);
+    printf("  %s\n\n", t5_pass ? "PASS" : "FAIL");
+    if (t5_pass) pass_count++; else fail_count++;
+
+    clReleaseMemObject(d_filt_idx);
+    clReleaseMemObject(d_filt_mi);
+    clReleaseMemObject(d_filt_cnt);
+
+    /* ═══════════════════════════════════════════════════════════════
+     *  TEST 6: Benchmark — 1000 sentences → MI
+     *
+     *  Full pipeline: count 1000 sentences then compute MI.
+     *  Measures the end-to-end time with zero CPU↔GPU transfers
+     *  between stages.
+     * ═══════════════════════════════════════════════════════════════ */
+
+    printf("--- Test 6: Benchmark (1000 sentences → MI) ---\n");
+
+    reset_pools(queue, pht_keys, pht_values, pair_count, pair_mi,
+                pair_flags, word_count, pair_next_free, total_pair_count);
+
+    /* Generate 1000 sentences */
+    int bench_ns = 1000;
+    uint32_t* bench_offsets = malloc(sizeof(uint32_t) * bench_ns);
+    uint32_t* bench_lengths = malloc(sizeof(uint32_t) * bench_ns);
+
+    uint64_t rng = 0xCAFEBABEDEADBEEFULL;
+    uint32_t bench_tw = 0;
+    for (int s = 0; s < bench_ns; s++) {
+        bench_offsets[s] = bench_tw;
+        rng += 0x9E3779B97F4A7C15ULL;
+        bench_lengths[s] = 5 + (uint32_t)((rng >> 32) % 16);
+        bench_tw += bench_lengths[s];
+    }
+
+    uint32_t* bench_words = malloc(sizeof(uint32_t) * bench_tw);
+    rng = 0xFEEDFACE12345678ULL;
+    for (uint32_t i = 0; i < bench_tw; i++) {
+        rng += 0x9E3779B97F4A7C15ULL;
+        double u = (double)(rng >> 32) / (double)0xFFFFFFFFU;
+        bench_words[i] = (uint32_t)(u * u * 499.0);
+    }
+
+    printf("  Sentences: %d, Total words: %u\n", bench_ns, bench_tw);
+
+    clReleaseMemObject(d_flat_words);
+    clReleaseMemObject(d_sent_offsets);
+    clReleaseMemObject(d_sent_lengths);
+
+    d_flat_words = clCreateBuffer(ctx, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint32_t) * bench_tw, bench_words, &err);
+    d_sent_offsets = clCreateBuffer(ctx, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint32_t) * bench_ns, bench_offsets, &err);
+    d_sent_lengths = clCreateBuffer(ctx, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint32_t) * bench_ns, bench_lengths, &err);
+
+    cl_uint bns = bench_ns;
+    cl_uint bench_window = 6;
+
+    clSetKernelArg(k_count, 0, sizeof(cl_mem), &d_flat_words);
+    clSetKernelArg(k_count, 1, sizeof(cl_mem), &d_sent_offsets);
+    clSetKernelArg(k_count, 2, sizeof(cl_mem), &d_sent_lengths);
+    clSetKernelArg(k_count, 3, sizeof(cl_uint), &bns);
+    clSetKernelArg(k_count, 4, sizeof(cl_uint), &bench_tw);
+    clSetKernelArg(k_count, 5, sizeof(cl_uint), &bench_window);
+    clSetKernelArg(k_count, 6, sizeof(cl_mem), &pht_keys);
+    clSetKernelArg(k_count, 7, sizeof(cl_mem), &pht_values);
+    clSetKernelArg(k_count, 8, sizeof(cl_mem), &pair_word_a);
+    clSetKernelArg(k_count, 9, sizeof(cl_mem), &pair_word_b);
+    clSetKernelArg(k_count, 10, sizeof(cl_mem), &pair_count);
+    clSetKernelArg(k_count, 11, sizeof(cl_mem), &pair_mi);
+    clSetKernelArg(k_count, 12, sizeof(cl_mem), &pair_flags);
+    clSetKernelArg(k_count, 13, sizeof(cl_mem), &pair_next_free);
+    clSetKernelArg(k_count, 14, sizeof(cl_mem), &word_count);
+    clSetKernelArg(k_count, 15, sizeof(cl_mem), &total_pair_count);
+
+    /* Stage 1: Count */
+    t0 = now_ms();
+    gs = ((bench_tw + local_size - 1) / local_size) * local_size;
+    clEnqueueNDRangeKernel(queue, k_count, 1, NULL,
+        &gs, &local_size, 0, NULL, NULL);
+    clFinish(queue);
+    t1 = now_ms();
+    double count_ms = t1 - t0;
+
+    clEnqueueReadBuffer(queue, pair_next_free, CL_TRUE, 0,
+        sizeof(uint32_t), &h_num_pairs, 0, NULL, NULL);
+    clEnqueueReadBuffer(queue, total_pair_count, CL_TRUE, 0,
+        sizeof(uint32_t), &h_total, 0, NULL, NULL);
+
+    printf("  Count: %u pairs, %u events in %.2f ms\n",
+           h_num_pairs, h_total, count_ms);
+
+    /* Stage 2: MI on all pairs */
+    n = (double)h_total;
+    clSetKernelArg(k_mi_all, 5, sizeof(cl_double), &n);
+    clSetKernelArg(k_mi_all, 6, sizeof(cl_uint), &h_num_pairs);
+
+    t0 = now_ms();
+    gs = ((h_num_pairs + local_size - 1) / local_size) * local_size;
+    clEnqueueNDRangeKernel(queue, k_mi_all, 1, NULL,
+        &gs, &local_size, 0, NULL, NULL);
+    clFinish(queue);
+    t1 = now_ms();
+    double mi_ms = t1 - t0;
+
+    printf("  MI:    %u pairs in %.2f ms (%.1f M pairs/sec)\n",
+           h_num_pairs, mi_ms,
+           h_num_pairs / (mi_ms / 1000.0) / 1e6);
+
+    /* Stage 3: MI stats */
+    cl_mem d_s_nz = clCreateBuffer(ctx, CL_MEM_READ_WRITE | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint32_t), &zero, &err);
+    cl_mem d_s_pos = clCreateBuffer(ctx, CL_MEM_READ_WRITE | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint32_t), &zero, &err);
+    cl_mem d_s_at = clCreateBuffer(ctx, CL_MEM_READ_WRITE | CL_MEM_COPY_HOST_PTR,
+        sizeof(uint32_t), &zero, &err);
+
+    threshold = 1.0;
+    clSetKernelArg(k_mi_stats, 0, sizeof(cl_mem), &pair_mi);
+    clSetKernelArg(k_mi_stats, 1, sizeof(cl_mem), &pair_count);
+    clSetKernelArg(k_mi_stats, 2, sizeof(cl_uint), &h_num_pairs);
+    clSetKernelArg(k_mi_stats, 3, sizeof(cl_double), &threshold);
+    clSetKernelArg(k_mi_stats, 4, sizeof(cl_mem), &d_s_nz);
+    clSetKernelArg(k_mi_stats, 5, sizeof(cl_mem), &d_s_pos);
+    clSetKernelArg(k_mi_stats, 6, sizeof(cl_mem), &d_s_at);
+
+    t0 = now_ms();
+    clEnqueueNDRangeKernel(queue, k_mi_stats, 1, NULL,
+        &gs, &local_size, 0, NULL, NULL);
+    clFinish(queue);
+    double stats_ms = now_ms() - t0;
+
+    clEnqueueReadBuffer(queue, d_s_nz, CL_TRUE, 0, sizeof(uint32_t), &cnt_nz, 0, NULL, NULL);
+    clEnqueueReadBuffer(queue, d_s_pos, CL_TRUE, 0, sizeof(uint32_t), &cnt_pos, 0, NULL, NULL);
+    clEnqueueReadBuffer(queue, d_s_at, CL_TRUE, 0, sizeof(uint32_t), &cnt_at, 0, NULL, NULL);
+
+    printf("  Stats: %u nonzero, %u positive MI, %u MI>%.1f in %.2f ms\n",
+           cnt_nz, cnt_pos, cnt_at, threshold, stats_ms);
+
+    /* Stage 4: Dirty MI (incremental — count another batch, recompute dirty only) */
+
+    /* Reset only the counting state, keep existing MI values */
+    /* First record current pair count */
+    uint32_t pairs_before = h_num_pairs;
+
+    /* Count same sentences again (adds to counts, marks dirty) */
+    clSetKernelArg(k_count, 3, sizeof(cl_uint), &bns);
+    clSetKernelArg(k_count, 4, sizeof(cl_uint), &bench_tw);
+
+    t0 = now_ms();
+    gs = ((bench_tw + local_size - 1) / local_size) * local_size;
+    clEnqueueNDRangeKernel(queue, k_count, 1, NULL,
+        &gs, &local_size, 0, NULL, NULL);
+    clFinish(queue);
+    double count2_ms = now_ms() - t0;
+
+    clEnqueueReadBuffer(queue, pair_next_free, CL_TRUE, 0,
+        sizeof(uint32_t), &h_num_pairs, 0, NULL, NULL);
+    clEnqueueReadBuffer(queue, total_pair_count, CL_TRUE, 0,
+        sizeof(uint32_t), &h_total, 0, NULL, NULL);
+
+    printf("  Count (batch 2): %u pairs, %u events in %.2f ms\n",
+           h_num_pairs, h_total, count2_ms);
+    printf("  New pairs: %u (existing reused: %u)\n",
+           h_num_pairs - pairs_before, pairs_before);
+
+    /* Dirty MI recompute */
+    n = (double)h_total;
+    clSetKernelArg(k_mi_dirty, 6, sizeof(cl_double), &n);
+    clSetKernelArg(k_mi_dirty, 7, sizeof(cl_uint), &h_num_pairs);
+
+    t0 = now_ms();
+    gs = ((h_num_pairs + local_size - 1) / local_size) * local_size;
+    clEnqueueNDRangeKernel(queue, k_mi_dirty, 1, NULL,
+        &gs, &local_size, 0, NULL, NULL);
+    clFinish(queue);
+    double dirty_ms = now_ms() - t0;
+
+    printf("  Dirty MI: %u pairs scanned in %.2f ms\n", h_num_pairs, dirty_ms);
+    printf("\n  === Pipeline Summary ===\n");
+    printf("  Count (1000 sent):    %.2f ms\n", count_ms);
+    printf("  MI (all %u pairs):    %.2f ms\n", pairs_before, mi_ms);
+    printf("  Stats:                %.2f ms\n", stats_ms);
+    printf("  Count (batch 2):      %.2f ms\n", count2_ms);
+    printf("  MI (dirty only):      %.2f ms\n", dirty_ms);
+    printf("  Total pipeline:       %.2f ms\n",
+           count_ms + mi_ms + stats_ms + count2_ms + dirty_ms);
+    printf("  CPU↔GPU transfers:    0 (all data GPU-resident)\n");
+
+    int t6_pass = (h_num_pairs > 0) && (h_total > 0) && (cnt_nz > 0);
+    printf("  %s\n\n", t6_pass ? "PASS" : "FAIL");
+    if (t6_pass) pass_count++; else fail_count++;
+
+    clReleaseMemObject(d_s_nz);
+    clReleaseMemObject(d_s_pos);
+    clReleaseMemObject(d_s_at);
+
+    /* ═══ Summary ═══ */
+
+    printf("=== Results: %d PASS, %d FAIL ===\n", pass_count, fail_count);
+
+    /* ─── Cleanup ─── */
+
+    clReleaseMemObject(pht_keys);
+    clReleaseMemObject(pht_values);
+    clReleaseMemObject(pair_word_a);
+    clReleaseMemObject(pair_word_b);
+    clReleaseMemObject(pair_count);
+    clReleaseMemObject(pair_mi);
+    clReleaseMemObject(pair_flags);
+    clReleaseMemObject(pair_next_free);
+    clReleaseMemObject(word_count);
+    clReleaseMemObject(total_pair_count);
+    clReleaseMemObject(d_flat_words);
+    clReleaseMemObject(d_sent_offsets);
+    clReleaseMemObject(d_sent_lengths);
+
+    clReleaseKernel(k_count);
+    clReleaseKernel(k_mi_all);
+    clReleaseKernel(k_mi_dirty);
+    clReleaseKernel(k_mi_stats);
+    clReleaseKernel(k_mi_filter);
+    clReleaseKernel(k_read_mi);
+    clReleaseProgram(program);
+    clReleaseCommandQueue(queue);
+    clReleaseContext(ctx);
+
+    free(bench_offsets);
+    free(bench_lengths);
+    free(bench_words);
+    free(combined);
+    free(ht_src);
+    free(as_src);
+    free(ct_src);
+    free(mi_src);
+
+    return fail_count > 0 ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

GPU kernels for the statistical learning stage — counting word co-occurrences and computing mutual information.

- **gpu-counting.cl** — Sentence pair counting with sliding-window approach. Processes tokenized sentences to extract word co-occurrence pairs using atomic increments for concurrent sentence processing.
- **gpu-mi.cl** — Mutual Information computation with two modes:
  - **Resident mode**: full recomputation over all pairs
  - **Dirty mode**: incremental updates for recently changed pairs only
  - Uses `double` precision to match AtomSpace `FloatValue` format

## Pipeline Position

This is **Phase 2-3** of the GPU-native AtomSpace pipeline:

```
 Phase 0-1: Hash Table + Pools (#3, dependency)
[Phase 2-3: Counting + MI] ← THIS PR
 Phase 4-5: Sections + Cosine  (#5)
 Phase 6:   Substitution       (#6)
```

> **Depends on PR #3** — these kernels reference `WordPool`, `PairPool`, and hash table structs defined in `gpu-atomspace.cl` and `gpu-hashtable.cl`. PR #3 should be merged first. No dependencies on PRs #5 or #6.

## Files

| File | Lines | Description |
|------|-------|-------------|
| `gpu-counting.cl` | 296 | Sliding-window pair counting kernel |
| `gpu-mi.cl` | 224 | MI computation (resident + dirty modes) |
| `test-counting.c` | 720 | Pair counting unit tests |
| `test-mi.c` | 961 | MI computation unit tests |

## Performance

- MI throughput: **385K pairs/sec** (1.24M pairs in ~3.2 seconds)
- Dirty mode avoids recomputing unchanged pairs, enabling incremental updates

## Building & Testing

```bash
cd opencog/opencl/atomspace

# Pair counting tests
gcc -o test-counting test-counting.c -lOpenCL -lm
./test-counting

# MI computation tests
gcc -o test-mi test-mi.c -lOpenCL -lm
./test-mi
```

## Relationship to Prior Work

Builds on PR #2 (binary caching + dispatch thread build), which was merged as `2a9c544`. These kernels benefit from the binary caching infrastructure for faster program load times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)